### PR TITLE
add github webhook to projects controller

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -66,7 +66,7 @@ Devise.setup do |config|
   # It can be set to an array that will enable http authentication only for the
   # given strategies, for example, `config.http_authenticatable = [:token]` will
   # enable it only for token authentication.
-  # config.http_authenticatable = false
+  config.http_authenticatable = true
 
   # If http headers should be returned for AJAX requests. True by default.
   # config.http_authenticatable_on_xhr = true
@@ -126,7 +126,7 @@ Devise.setup do |config|
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
   # config.timeout_in = 30.minutes
-  
+
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,10 @@ Shuttle::Application.routes.draw do
         end
       end
     end
+
+    member do
+      post 'pull-request-builder' => 'projects#github_webhook'
+    end
   end
 
   resources :locales, only: :index do


### PR DESCRIPTION
The changes are:
- new `github_webhook` method on `ProjectsController`
- new route matching `/project/:id/pull-request-builder` to the new method
- allow basic auth in devise

If you add `http://EMAIL:PASS@shuttle.example.com/project/PROJECTNAME/pull-request-builder` to the github webhooks for a project, assuming github can see Shuttle, then Shuttle should automatically add/process the latest commit whenever the repo is updated (provided the updated branch is being watched by Shuttle).
