### PR TITLE
Clarify: Taiwan is not a Province of China

### DIFF
--- a/config/locales/locales.en.yml
+++ b/config/locales/locales.en.yml
@@ -8445,7 +8445,7 @@ en:
       TT: Trinidad and Tobago
       TV: Tuvalu
       TW: Taiwan
-      TZ: United Republic of Tanzani
+      TZ: United Republic of Tanzania
       UA: Ukraine
       UG: Uganda
       UM: United States Minor Outlying Islands


### PR DESCRIPTION
Well it's a political and ISO 3166 problem. But anyway we don't recognize Taiwan as a Province of China, so it would be really nice to remove the suffix from Taiwan.  

More info here: 
http://www.change.org/petitions/iso-central-secretariat-change-the-present-taiwan-province-of-china-to-taiwan

Thanks!
