### PR TITLE
Importing speedup

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -709,7 +709,10 @@ class Commit < ActiveRecord::Base
     imps.each do |importer|
       importer = importer.new(blob_object, path, self)
 
-      Shuttle::Redis.del("keys_for_blob:#{importer.class.ident}:#{blob.sha}") if options[:force]
+      if options[:force]
+        blob_object.keys.clear
+        blob_object.update_column :keys_cached, false
+      end
 
       if importer.skip?(options[:locale])
         #Importer::SKIP_LOG.info "commit=#{revision} blob=#{blob.sha} path=#{blob_path} importer=#{importer.class.ident} #skip? returned true for #{options[:locale].inspect}"

--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -77,6 +77,7 @@ class Key < ActiveRecord::Base
   has_many :translations, inverse_of: :key, dependent: :destroy
   has_many :commits_keys, inverse_of: :key, dependent: :destroy
   has_many :commits, through: :commits_keys
+  has_and_belongs_to_many :blobs, -> { uniq }, association_foreign_key: [:project_id, :sha_raw]
 
   include HasMetadataColumn
   has_metadata_column(

--- a/app/workers/blob_importer.rb
+++ b/app/workers/blob_importer.rb
@@ -31,10 +31,10 @@ class BlobImporter
 
   def perform(importer, project_id, sha, path, commit_id, rfc5646_locale)
     begin
-      commit   = Commit.find_by_id(commit_id)
-      locale   = rfc5646_locale ? Locale.from_rfc5646(rfc5646_locale) : nil
-      project  = Project.find(project_id)
-      blob     = project.blobs.with_sha(sha).first!
+      commit  = Commit.find_by_id(commit_id)
+      locale  = rfc5646_locale ? Locale.from_rfc5646(rfc5646_locale) : nil
+      project = Project.find(project_id)
+      blob    = project.blobs.with_sha(sha).first!
 
       if blob.blob.nil?
         # for whatever reason sometimes the blob is not accessible; try again in
@@ -48,7 +48,8 @@ class BlobImporter
       blob.import_strings importer,
                           path,
                           commit: commit,
-                          locale: locale
+                          locale: locale,
+                          inline: jid.nil?
 
     ensure
       commit.try! :remove_worker!, jid

--- a/app/workers/key_creator.rb
+++ b/app/workers/key_creator.rb
@@ -1,0 +1,131 @@
+# Copyright 2014 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# Creates a set of {Key Keys} associated with a single {Blob} and {Commit}, as
+# part of an import job. Creates keys and then performs after-save hooks in
+# batch.
+
+class KeyCreator
+  include Sidekiq::Worker
+  sidekiq_options queue: :high
+
+  # Executes this worker.
+  #
+  # @param [Fixnum] project_id The ID of a {Blob}'s {Project} these Keys were
+  #   all imported from.
+  # @param [Fixnum] sha The SHA of a Blob these Keys were all imported from.
+  # @param [String] commit_id The ID of a {Commit} these Keys will be associated
+  #   with.
+  # @param [String] importer The identifier for the {Importer::Base} subclass
+  #   that imported these keys.
+  # @param [Array<Hash>] keys An array of key data.
+
+  def perform(project_id, sha, commit_id, importer, keys)
+    @blob     = Blob.where(project_id: project_id).with_sha(sha).first!
+    @commit   = Commit.find(commit_id) if commit_id
+    @importer = Importer::Base.find_by_ident(importer)
+
+    key_objects = keys.map do |key|
+      key.symbolize_keys!
+      key[:options].try! :symbolize_keys!
+      add_string key[:key], key[:value], (key[:options] || {})
+    end
+
+    @blob.keys = key_objects
+    @blob.update_column :keys_cached, true
+
+    if @commit
+      key_objects.reject! { |key| skip_key?(key) }
+      self.class.update_key_associations key_objects, @commit
+    end
+
+  ensure
+    @commit.try! :remove_worker!, jid
+  end
+
+  # Given a set of keys, bulk-updates their commits-keys associations and
+  # ElasticSearch `commit_ids` associations.
+  #
+  # @param [Array<Key>] keys A set of Keys to update.
+  # @param [Commit] commit A Commit these keys are associated with.
+
+  def self.update_key_associations(keys, commit)
+    Commit.transaction do
+      keys        -= commit.keys
+      commit.keys += keys
+    end
+
+    # key.commits has been changed, need to update associated ES fields
+    # load the translations associated with each commit
+    keys           = Key.where(id: keys.map(&:id)).includes(:translations)
+    # preload commits_keys by loading all possible commit ids
+    commits_by_key = CommitsKey.connection.select_rows(CommitsKey.select('commit_id, key_id').where(key_id: keys.map(&:id)).to_sql).inject({}) do |hsh, (cid, key_id)|
+      hsh[key_id.to_i] ||= Set.new
+      hsh[key_id.to_i] << cid.to_i
+      hsh
+    end
+    # organize them into their keys add add this new commit
+    keys.each do |key|
+      key.batched_commit_ids = commits_by_key[key.id] || Set.new
+      key.batched_commit_ids << commit.id
+    end
+    # and run the import
+    Key.tire.index.import keys
+    # now update translations with the keys still having the cached commit ids
+    Translation.tire.index.import keys.map(&:translations).flatten
+  end
+
+  private
+
+  def add_string(key, value, options={})
+    key = @blob.project.keys.for_key(key).source_copy_matches(value).create_or_update!(
+        options.reverse_merge(
+            key:                  key,
+            source_copy:          value,
+            importer:             @importer.ident,
+            fencers:              @importer.fencers,
+            skip_readiness_hooks: true,
+            batched_commit_ids:   []) # we'll fill this out later
+    )
+
+    key.translations.in_locale(@blob.project.base_locale).create_or_update!(
+        source_copy:              value,
+        copy:                     value,
+        approved:                 true,
+        source_rfc5646_locale:    @blob.project.base_rfc5646_locale,
+        rfc5646_locale:           @blob.project.base_rfc5646_locale,
+        skip_readiness_hooks:     true,
+        preserve_reviewed_status: true)
+
+    # add additional pending translations if necessary
+    key.add_pending_translations
+
+    return key
+  end
+
+  # Determines if we should skip this key using both the normal key exclusions
+  # and the .shuttle.yml key exclusions
+  def skip_key?(key)
+    skip_key_due_to_project_settings?(key) || skip_key_due_to_branch_settings?(key)
+  end
+
+  def skip_key_due_to_project_settings?(key)
+    @blob.project.skip_key?(key.key, @blob.project.base_locale)
+  end
+
+  def skip_key_due_to_branch_settings?(key)
+    return false unless @commit
+    @commit.skip_key?(key.key)
+  end
+end

--- a/db/migrate/20140306064700_create_blob_keys.rb
+++ b/db/migrate/20140306064700_create_blob_keys.rb
@@ -1,0 +1,21 @@
+class CreateBlobKeys < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE TABLE blobs_keys (
+        project_id integer NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        sha_raw bytea NOT NULL,
+        key_id INTEGER NOT NULL REFERENCES keys(id) ON DELETE CASCADE,
+        FOREIGN KEY (project_id, sha_raw) REFERENCES blobs(project_id, sha_raw) ON DELETE CASCADE,
+        PRIMARY KEY (project_id, sha_raw, key_id)
+      )
+    SQL
+
+    execute "ALTER TABLE blobs ADD keys_cached BOOLEAN NOT NULL DEFAULT FALSE"
+  end
+
+  def down
+    execute "ALTER TABLE blobs DROP keys_cached"
+
+    drop_table :blobs_keys
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -35,7 +35,19 @@ SET default_with_oids = false;
 CREATE TABLE blobs (
     project_id integer NOT NULL,
     sha_raw bytea NOT NULL,
-    metadata text
+    metadata text,
+    keys_cached boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: blobs_keys; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE blobs_keys (
+    project_id integer NOT NULL,
+    sha_raw bytea NOT NULL,
+    key_id integer NOT NULL
 );
 
 
@@ -435,6 +447,7 @@ CREATE TABLE users (
     role character varying(50) DEFAULT NULL::character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
+    confirmation_token character varying(255),
     CONSTRAINT users_email_check CHECK ((char_length((email)::text) > 0)),
     CONSTRAINT users_failed_attempts_check CHECK ((failed_attempts >= 0)),
     CONSTRAINT users_sign_in_count_check CHECK ((sign_in_count >= 0))
@@ -535,6 +548,14 @@ ALTER TABLE ONLY translations ALTER COLUMN id SET DEFAULT nextval('translations_
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+
+--
+-- Name: blobs_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY blobs_keys
+    ADD CONSTRAINT blobs_keys_pkey PRIMARY KEY (project_id, sha_raw, key_id);
 
 
 --
@@ -692,6 +713,13 @@ CREATE UNIQUE INDEX glossary_source_copy_sha ON glossary_entries USING btree (so
 
 
 --
+-- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_users_on_confirmation_token ON users USING btree (confirmation_token);
+
+
+--
 -- Name: keys_unique; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -766,6 +794,30 @@ CREATE UNIQUE INDEX users_reset_token ON users USING btree (reset_password_token
 --
 
 CREATE UNIQUE INDEX users_unlock_token ON users USING btree (unlock_token);
+
+
+--
+-- Name: blobs_keys_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY blobs_keys
+    ADD CONSTRAINT blobs_keys_key_id_fkey FOREIGN KEY (key_id) REFERENCES keys(id) ON DELETE CASCADE;
+
+
+--
+-- Name: blobs_keys_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY blobs_keys
+    ADD CONSTRAINT blobs_keys_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: blobs_keys_project_id_fkey1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY blobs_keys
+    ADD CONSTRAINT blobs_keys_project_id_fkey1 FOREIGN KEY (project_id, sha_raw) REFERENCES blobs(project_id, sha_raw) ON DELETE CASCADE;
 
 
 --
@@ -941,3 +993,7 @@ INSERT INTO schema_migrations (version) VALUES ('20131116042827');
 INSERT INTO schema_migrations (version) VALUES ('20131204020552');
 
 INSERT INTO schema_migrations (version) VALUES ('20140219040119');
+
+INSERT INTO schema_migrations (version) VALUES ('20140228025058');
+
+INSERT INTO schema_migrations (version) VALUES ('20140306064700');

--- a/spec/controllers/commits_controller_spec.rb
+++ b/spec/controllers/commits_controller_spec.rb
@@ -641,10 +641,10 @@ de:
     end
 
     it "should allow the description, due date, and pull request URL to be set" do
-      post :create, project_id: @project.to_param, commit: {revision: 'HEAD', description: 'desc', pull_request_url: 'url', due_date: Date.today.tomorrow}, format: 'json'
+      post :create, project_id: @project.to_param, commit: {revision: 'HEAD', description: 'desc', pull_request_url: 'url', due_date: '1/1/2100'}, format: 'json'
       expect(@project.commits.first.description).to eql('desc')
       expect(@project.commits.first.pull_request_url).to eql('url')
-      expect(@project.commits.first.due_date).to eql(Date.today.tomorrow)
+      expect(@project.commits.first.due_date).to eql(Date.civil(2100, 1, 1))
     end
 
     it "should not attempt to import the same revision twice in quick succession" do

--- a/spec/models/blob_spec.rb
+++ b/spec/models/blob_spec.rb
@@ -22,17 +22,19 @@ describe Blob do
     end
 
     it "should call #import on an importer subclass" do
-      imp = Importer::Base.implementations
+      imp      = Importer::Base.implementations
       instance = double(imp.to_s, :skip? => false)
       expect(imp).to receive(:new).once.with(@blob, 'some/path', nil).and_return(instance)
+      allow(instance).to receive(:inline=)
       expect(instance).to receive(:import).once
       @blob.import_strings imp, 'some/path'
     end
 
     it "should pass a commit if given using :commit" do
-      commit = FactoryGirl.create(:commit, project: @project)
-      imp = Importer::Base.implementations.first
+      commit   = FactoryGirl.create(:commit, project: @project)
+      imp      = Importer::Base.implementations.first
       instance = double(imp.to_s, :skip? => false)
+      allow(instance).to receive(:inline=)
       expect(imp).to receive(:new).once.with(@blob, 'some/path', commit).and_return(instance)
       expect(instance).to receive(:import).once
       @blob.import_strings imp, 'some/path', commit: commit


### PR DESCRIPTION
@RickCSong
1. Separate file parsing and key creation into separate workers
2. Change Blob key caching to a database table

1.

To speed importing, this commit extracts the key-creation code away from
`BlobImporter` and puts it in a new worker, `KeyCreator`, leaving
`BlobImporter` to strictly do file parsing.

Now, as `BlobImporter` parses a file, it builds an array of key data. This data
is segmented in groups of 100, and each group is sent to a `KeyCreator` worker
for processing. `KeyCreator` batch-creates the keys, and does the bulk
ElasticSearch updates and association updates.

In order to prevent `Commit#loading` from becoming false prematurely, the
`BlobImporter` adds the `KeyCreator`'s job ID to the commit's loading list the
same way that the `Commit` adds the `BlobImporter`'s JID to its loading list.
The `KeyCreator` has the same logic to remove itself from the loading list as
the `BlobImporter`. A commit will not finish loading until all `BlobImporter`s
_and_ `KeyCreator`s have finished.

All of the code dealing with creating keys has been moved from `Importer::Base`
to `KeyCreator` (the exception being locale imports, which I generally consider
to be deprecated at this point).

In order to continue to support inline imports, the `:inline` option must be
further passed down the import call chain. Now, `Importer::Base` has a
`#inline` attr_accessor that is set by `Blob#import_strings`, which is passed
the value by the `BlobImporter`.

2.

Formerly, keys found in a blob in the course of importing were cached in Redis,
the thought being that if the blob were again encountered in later commits, the
cached keys could simply be added to the new commit. This code never actually
worked.

So a `blobs_keys` table has been added and a `has_and_belongs_to_many`
association created between `Blob` and `Key`. Now, the first time a blob is
encountered, this association is populated with all the found keys. Future
imports will use those cached keys, bypassing the parsing and key creation
steps, unless the `:force` option is used.

The `cached_keys` column on `blobs` records whether the blobs_keys association
is fresh.
