### PR TITLE
Remove `brew upgarde` from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,6 @@
 update
-upgrade
 install libarchive
 install postgresql
-install redis elasticsearch
+install redis
+install elasticsearch
 install qt


### PR DESCRIPTION
`brew upgrade` will upgrade all outdated formulae installed on maching.
This is not neccessary to upgrade other formulae that not used by Shuttle, and will cause problems for users that don't want to upgrade installed formulae for some reasons.
