### PR TITLE
Adds flip switch for blacklist/whitelist for project

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -39,13 +39,14 @@
 @import "partials/alerts";
 @import "partials/chosen";
 @import "partials/datepicker";
+@import "partials/flipswitch";
 @import "partials/footer";
 @import "partials/infinite_scroll";
 @import "partials/locale_field";
 @import "partials/multi_field";
 @import "partials/modal";
 @import "partials/navbar";
+@import "partials/tooltip";
 @import "partials/translation_workbench";
 @import "partials/worker_status";
-@import "partials/tooltip";
 @import "partials/highlighter";

--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -63,3 +63,7 @@ hr.divider {
   margin-top: 5px;
   margin-bottom: 40px;
 }
+
+.hide {
+  display: none;
+}

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -1,3 +1,4 @@
+@import "css3-mixins";
 @import "base/vars";
 @import "css3-mixins";
 
@@ -19,8 +20,16 @@ form#new_project {
   }
 }
 
+.flipswitch {
+  float: right;
+  margin-bottom: -30px;
+}
+
 fieldset {
   padding: 20px 0px 50px 0px;
+  width: 100%;
+  @include transition(height);
+//  @include transition-duration(250ms);
 }
 
 legend {

--- a/app/assets/stylesheets/pages/projects.css.scss
+++ b/app/assets/stylesheets/pages/projects.css.scss
@@ -113,3 +113,18 @@ body.projects {
   }
 
 }
+
+#projects-edit {
+  .flipswitch-inner:before {
+    content: "BLACKLIST";
+    padding-left: 8px;
+    background-color: #666666; color: #FFFFFF;
+  }
+
+  .flipswitch-inner:after {
+    content: "WHITELIST";
+    padding-right: 8px;
+    background-color: #F0F0F0; color: #666666;
+    text-align: right;
+  }
+}

--- a/app/assets/stylesheets/partials/_flipswitch.scss
+++ b/app/assets/stylesheets/partials/_flipswitch.scss
@@ -1,0 +1,42 @@
+.flipswitch {
+  position: relative; width: 130px;
+  -webkit-user-select:none; -moz-user-select:none; -ms-user-select: none;
+}
+
+.flipswitch-checkbox {
+  display: none !important;
+}
+
+.flipswitch-label {
+  display: block; overflow: hidden; cursor: pointer;
+  border: 2px solid #666666; border-radius: 2px;
+}
+
+.flipswitch-inner {
+  width: 200%; margin-left: -100%;
+  -moz-transition: margin 0.3s ease-in 0s; -webkit-transition: margin 0.3s ease-in 0s;
+  -o-transition: margin 0.3s ease-in 0s; transition: margin 0.3s ease-in 0s;
+}
+
+.flipswitch-inner:before, .flipswitch-inner:after {
+  float: left; width: 50%; height: 30px; padding: 0; line-height: 30px;
+  font-size: 14px; color: white; font-family: Trebuchet, Arial, sans-serif; font-weight: bold;
+  -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
+}
+
+.flipswitch-switch {
+  width: 30px; margin: 0px;
+  background: #FFFFFF;
+  border: 2px solid #666666; border-radius: 2px;
+  position: absolute; top: 0; bottom: 0; right: 96px;
+  -moz-transition: all 0.3s ease-in 0s; -webkit-transition: all 0.3s ease-in 0s;
+  -o-transition: all 0.3s ease-in 0s; transition: all 0.3s ease-in 0s;
+}
+
+.flipswitch-checkbox:checked + .flipswitch-label .flipswitch-inner {
+  margin-left: 0;
+}
+
+.flipswitch-checkbox:checked + .flipswitch-label .flipswitch-switch {
+  right: 0px;
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -262,6 +262,18 @@ class ProjectsController < ApplicationController
     targeted_rfc5646_locales = targeted_rfc5646_locales.merge(
       Hash[params[:project][:other_rfc5646_locales].map {|locale| [locale, false]}]
     )
+
+    if params[:use_key_exclusions]
+      params[:project][:key_inclusions] = []
+    else
+      params[:project][:key_exclusions] = []
+    end
+
+    if params[:use_skip_paths]
+      params[:project][:only_paths] = []
+    else
+      params[:project][:skip_paths] = []
+    end
     
     project_params = params[:project].to_hash.slice(*%w(
         name repository_url base_rfc5646_locale due_date cache_localization

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -90,14 +90,13 @@ class Project < ActiveRecord::Base
       targeted_rfc5646_locales: {presence: true, type: Hash, default: {'en' => true}},
 
       skip_imports:             {type: Array, default: []},
-
       key_exclusions:           {type: Array, default: [], allow_nil: false},
       key_inclusions:           {type: Array, default: [], allow_nil: false},
       key_locale_exclusions:    {type: Hash, default: {}, allow_nil: false},
       key_locale_inclusions:    {type: Hash, default: {}, allow_nil: false},
 
-      only_paths:               {type: Array, default: [], allow_nil: false},
       skip_paths:               {type: Array, default: [], allow_nil: false},
+      only_paths:               {type: Array, default: [], allow_nil: false},
       skip_importer_paths:      {type: Hash, default: {}, allow_nil: false},
       only_importer_paths:      {type: Hash, default: {}, allow_nil: false},
 

--- a/app/views/projects/_form.js.coffee.erb
+++ b/app/views/projects/_form.js.coffee.erb
@@ -77,11 +77,29 @@ $(document).ready () ->
         valueField.arrayField()
     )
 
+  $('.flipswitch-checkbox').each (i) ->
+    id = $(this).attr('id')
+    checked_elt = $("##{id}-checked")
+    unchecked_elt = $("##{id}-unchecked")
+
+    if $(this).is(':checked')
+      unchecked_elt.hide()
+    else
+      checked_elt.hide()
+
+    $(this).on 'change', ->
+      if $(this).is(':checked')
+        unchecked_elt.fadeOut ->
+          checked_elt.fadeIn()
+      else
+        checked_elt.fadeOut ->
+          unchecked_elt.fadeIn()
+
   if (window.localesLoaded)
     setupLocaleField()
     setupKeyFields()
     setupPathFields()
   else 
-    $(document).bind('locales_loaded', setupLocaleField);
-    $(document).bind('locales_loaded', setupKeyFields);
-    $(document).bind('locales_loaded', setupPathFields);
+    $(document).bind('locales_loaded', setupLocaleField)
+    $(document).bind('locales_loaded', setupKeyFields)
+    $(document).bind('locales_loaded', setupPathFields)

--- a/app/views/projects/_form.slim
+++ b/app/views/projects/_form.slim
@@ -157,57 +157,66 @@
 
 
     .eight.columns.right-side
+      .flipswitch
+        input#key-flipswitch.flipswitch-checkbox checked=@project.key_inclusions.empty? name="project[use_key_exclusions]" type="checkbox"
+          label.flipswitch-label for="key-flipswitch"
+            .flipswitch-inner
+            .flipswitch-switch
+      fieldset
+        legend Key Filtering
 
-      fieldset 
-        legend Key Whitelisting and Blacklisting
-        
-        .space-group
+        .space-group#key-flipswitch-unchecked
           = f.label :key_inclusions, class: 'control-label'
           p.help-block List the keys that must be translated. If at least one inclusion is given, keys not matching will not be translated. UNIX-style globs are supported.
-          .controls 
+          .controls
             = f.content_tag_field 'div', :key_inclusions, class: 'array-field', 'data-value' => @project.key_inclusions.to_json
-          
         
-        .space-group        
+        .space-group#key-flipswitch-checked
           = f.label :key_exclusions, class: 'control-label'
           p.help-block List the keys you do not want to be translated. UNIX-style globs are supported.
           .controls
             = f.content_tag_field 'div', :key_exclusions, class: 'array-field', 'data-value' => @project.key_exclusions.to_json
-          
+
+      fieldset
+        legend Locale Key Filtering
         
-        .space-group        
+        .space-group
           = f.label :key_locale_inclusions, class: 'control-label'
           p.help-block List the keys that must be translated. If at least one inclusion is given, keys not matching will not be translated. UNIX-style globs are supported.
           .controls
             = f.content_tag_field 'div', :key_locale_inclusions, class: 'hash-field', 'data-value' => @project.key_locale_inclusions.to_json
           
         
-        .space-group        
+        .space-group
           = f.label :key_locale_exclusions, class: 'control-label'
           p.help-block List the keys you do not want to be translated. UNIX-style globs are supported.
           .controls
             = f.content_tag_field 'div', :key_locale_exclusions, class: 'hash-field', 'data-value' => @project.key_locale_exclusions.to_json
 
-          
-      
 
-
+      .flipswitch
+        input#path-flipswitch.flipswitch-checkbox checked=@project.only_paths.empty? name="project[use_skip_paths]" type="checkbox"
+          label.flipswitch-label for="path-flipswitch"
+            .flipswitch-inner
+            .flipswitch-switch
       fieldset 
-        legend Path Whitelisting and Blacklisting
-        
-        .space-group        
+        legend Path Filtering
+
+        .space-group#path-flipswitch-unchecked
           = f.label :only_paths, class: 'control-label'
           p.help-block List paths that importers will search for strings. Paths not in this list will not be searched.
           .controls
             = f.content_tag_field 'div', :only_paths, class: 'array-field', 'data-value' => @project.only_paths.to_json
         
         
-        .space-group        
+        .space-group#path-flipswitch-checked
           = f.label :skip_paths, class: 'control-label'
           p.help-block List paths you do not want any importers to scan under for strings.
           .controls
             = f.content_tag_field 'div', :skip_paths, class: 'array-field', 'data-value' => @project.skip_paths.to_json
-          
+
+      fieldset
+        legend Importer Path Filtering
         
         .space-group        
           = f.label :only_importer_paths, class: 'control-label'
@@ -223,7 +232,7 @@
             = f.content_tag_field 'div', :skip_importer_paths, class: 'hash-field', 'data-value' => @project.skip_importer_paths.to_json
 
   .form-actions
-    = f.submit class: 'primary', value: 'save'
+    = f.submit class: 'primary', value: 'save', data: { confirm: 'Are you sure?  Changes are irreversible.'}
     button.default href=projects_url Cancel           
           
 - content_for :javascript do 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -15,8 +15,6 @@
 require 'spec_helper'
 
 describe ProjectsController do
-  pending "Write specs" #TODO
-
   describe '#github_webhook' do
     before :all do
       @user = FactoryGirl.create(:user, role: 'monitor')


### PR DESCRIPTION
@yunussasmaz @RISCfuture 

I'm not the biggest fan of how this works.  Note that if a user sets switches from a blacklist to a whitelist, all his previous blacklist settings will be _lost_.  

However, on the flipside, if we decide to use a "use_key_exclusion" metadata field, we'll require a migration to ensure that importers are still working correctly.  

On the fence.  If no comments, I may merge it and come back to the issue depending on complaints. 
