### PR TITLE
Fix over eager join in locale_projects_show_finder

### DIFF
--- a/app/services/locale_projects_show_finder.rb
+++ b/app/services/locale_projects_show_finder.rb
@@ -117,9 +117,8 @@ class LocaleProjectsShowFinder
     translations_in_es = Elasticsearch::Model.search(search_query, Translation).results
     translations = Translation
                        .where(id: translations_in_es.map(&:id))
-                       .joins(key: :commits)
                        .where('commits.revision': form[:commit])
-                       .includes({key: [:project, :translations, :section, {article: :project}]}, :locale_associations)
+                       .includes({key: [:project, :commits, :translations, :section, {article: :project}]}, :locale_associations)
                        .order('commits_keys.created_at, keys.original_key')
 
     # Don't sort the keys since they are sorted in the line above


### PR DESCRIPTION
`spec/controllers/locales/projects_controller_spec.rb` was failing after #132. I believe this fixes it without changing the behavior of the controller.

`joins` creates an inner join which is too restrictive and excludes translations that do not have commits. Moving it to `includes` flips it to an outer join.

cc: @visoft 