### PR TITLE
Backlog Report

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -114,6 +114,20 @@ class StatsController < ApplicationController
     end
   end
 
+  def backlog_report
+  end
+
+  def generate_backlog_report
+    begin
+      start_date =  Date.strptime(params[:start_date], '%m/%d/%Y')
+      end_date =  Date.strptime(params[:end_date], '%m/%d/%Y')
+      filename = "backlog-report-#{start_date.strftime('%Y-%m-%d')}-to-#{end_date.strftime('%Y-%m-%d')}.csv"
+      send_data Reports::BacklogReport.generate_csv(start_date, end_date), filename: filename
+    rescue
+      render text: t('stats.reports.failure'), status: 400
+    end
+  end
+
   private
 
   def generate_commit_csv

--- a/app/views/layouts/_navbar.slim
+++ b/app/views/layouts/_navbar.slim
@@ -39,6 +39,7 @@ nav.navbar.navbar-dark
             = nav_dropdown_link "Project Translation Report", "stats", "project_translation_report", stats_project_translation_report_url
             = nav_dropdown_link "Incoming New Words Report", "stats", "incoming_new_words_report", stats_incoming_new_words_report_url
             = nav_dropdown_link "Translator Report", "stats", "translator_report", stats_translator_report_url
+            = nav_dropdown_link "Backlog Report", "stats", "backlog_report", stats_backlog_report_url
 
         - if current_user.admin?
           = nav_link "Users", "users", users_path

--- a/app/views/stats/backlog_report.slim
+++ b/app/views/stats/backlog_report.slim
@@ -1,0 +1,14 @@
+- content_for :shuttle_title do
+  = "Backlog Report - Shuttle"
+- content_for :file_name do
+  = 'views/stats/backlog_report'
+
+.header
+  h1 Backlog Report
+hr.dividers
+
+.translation_report
+  = form_tag stats_generate_backlog_report_path(format: :csv)
+    = render partial: 'stats/date_fields'
+    .form-actions
+      = submit_tag 'Get Report', class: 'btn btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,8 @@ Shuttle::Application.routes.draw do
   post 'stats/generate-incoming-new-words-report' => 'stats#generate_incoming_new_words_report', as: :stats_generate_incoming_new_words_report, format: :csv
   get 'stats/translator-report' => 'stats#translator_report', as: :stats_translator_report
   post 'stats/generate-translator-report' => 'stats#generate_translator_report', as: :stats_generate_translator_report, format: :csv
+  get 'stats/backlog-report' => 'stats#backlog_report', as: :stats_backlog_report
+  post 'stats/generate-backlog-report' => 'stats#generate_backlog_report', as: :stats_generate_backlog_report, format: :csv
 
   # GLOSSARY PAGES
   get 'glossary' => 'glossary#index', as: :glossary

--- a/lib/reports/backlog_report.rb
+++ b/lib/reports/backlog_report.rb
@@ -1,0 +1,60 @@
+# Copyright 2018 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+module Reports
+  module BacklogReport
+    def self.generate_csv(start_date, end_date)
+      # verify that the params are dates
+      raise ArgumentError, 'start_date is not a date' unless start_date.instance_of?(Date)
+      raise ArgumentError, 'end_date is not a date' unless end_date.instance_of?(Date)
+
+      # verify that the end date is after the start dates
+      raise ArgumentError, 'end_date cannot be earlier than the start date' if end_date < start_date
+
+      CSV.generate do |csv|
+        translations  = Translation.where('rfc5646_locale != source_rfc5646_locale')
+                                   .select('DATE(created_at) as created_at', 'DATE(translation_date) as translation_date', :rfc5646_locale, :words_count)
+
+        languages = translations.map(&:rfc5646_locale).uniq.sort
+        lang_count = languages.count
+        empty_cols = Array.new(lang_count, '')
+
+        csv << ['Start Date', start_date] + empty_cols
+        csv << ['End Date', end_date] + empty_cols
+        csv << ['Backlog Word Report', ''] + empty_cols
+        csv << ['', ''] + empty_cols
+        csv << ['Date', ''] + languages.map {|l| "#{l} (total words)"}
+
+        start_date.upto(end_date).each do |date|
+          row = [date.strftime('%Y-%m-%d'), '']
+
+          # for each date, find the number of new words for each language
+          languages.each do |language|
+            words = translations.select do |t|
+              t.rfc5646_locale == language &&
+              date >= t.created_at &&
+              (t.translation_date == nil || t.translation_date > date)
+            end
+
+            lang_total = words.sum(&:words_count) || 0
+            row += [lang_total]
+          end
+
+          # exclude empty rows (all zeroes)
+          csv << row unless (row[(lang_count * -1), lang_count]).reduce(:+) == 0
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -226,4 +226,31 @@ RSpec.describe StatsController do
       expect(response).to be_success
     end
   end
+
+  describe "#generate_backlog_report" do
+    before do
+      @start_date = Date.today
+      @end_date = @start_date.next_month
+    end
+
+    it 'has a response of 400 if start_date is nil' do
+      post :generate_backlog_report, format: :csv, start_date: nil, end_date: @end_date.strftime('%m/%d/%Y')
+      expect(response.status).to eq 400
+    end
+
+    it 'has a response of 400 if if end_date is nil' do
+      post :generate_backlog_report, format: :csv, start_date: @start_date.strftime('%m/%d/%Y'), end_date: nil
+      expect(response.status).to eq 400
+    end
+
+    it 'throws an exception if end_date is before start_date' do
+      post :generate_backlog_report, format: :csv, start_date: @end_date.strftime('%m/%d/%Y'), end_date: @start_date.strftime('%m/%d/%Y')
+      expect(response.status).to eq 400
+    end
+
+    it 'sends a csv file to the client' do
+      post :generate_backlog_report, format: :csv, start_date: @start_date.strftime('%m/%d/%Y'), end_date: @end_date.strftime('%m/%d/%Y')
+      expect(response).to be_success
+    end
+  end
 end

--- a/spec/lib/reports/backlog_report_spec.rb
+++ b/spec/lib/reports/backlog_report_spec.rb
@@ -1,0 +1,95 @@
+# Copyright 2018 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+require 'rails_helper'
+
+RSpec.describe Reports::BacklogReport do
+  describe '#generate_csv' do
+    it 'throws an exception if start_date is nil' do
+      expect { Reports::BacklogReport.generate_csv(nil, Date.today) }.to raise_error(ArgumentError)
+    end
+
+    it 'throws an exception if end_date is nil' do
+      expect { Reports::BacklogReport.generate_csv(Date.today, nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'throws an exception if end_date is before start_date' do
+      start_date = Date.today
+      end_date = start_date.prev_year
+
+      expect { Reports::BacklogReport.generate_csv(start_date, end_date) }.to raise_error(ArgumentError)
+    end
+
+    describe 'CSV Data' do
+      before :context do
+        @start_date = Date.today
+        @end_date = @start_date.next_month
+        @created_at = @start_date.next_day
+        @translation_date = @created_at + 2
+
+        project = FactoryBot.create(:project, name: 'Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
+        key1 = FactoryBot.create(:key, project: project)
+        key2 = FactoryBot.create(:key, project: project)
+        key3 = FactoryBot.create(:key, project: project)
+
+        FactoryBot.create(:translation, key: key1, translation_date: @translation_date, source_copy: 'This is a test', rfc5646_locale: 'fr', created_at: @created_at)
+        FactoryBot.create(:translation, key: key2, translation_date: @translation_date, source_copy: 'Another test', rfc5646_locale: 'it', created_at: @created_at)
+        FactoryBot.create(:translation, key: key3, translation_date: nil, source_copy: 'Final test',rfc5646_locale: 'it', created_at: @created_at)
+
+        csv = Reports::BacklogReport.generate_csv(@start_date, @end_date)
+        @result = CSV.parse(csv)
+      end
+
+      it 'has the expected start and end date' do
+        expected_results = [
+          ["Start Date", @start_date.strftime("%Y-%m-%d"), "", ""],
+          ["End Date", @end_date.strftime("%Y-%m-%d"), "", ""]
+        ]
+
+        expect(@result[0..1]).to eql expected_results
+      end
+
+      it 'has the row headers' do
+        expected_results = ["Date", "", "fr (total words)", "it (total words)"]
+
+        expect(@result[4]).to eql expected_results
+      end
+
+      it 'has has the correct data (row 4, day 1)' do
+        expected_results = [@created_at.strftime("%Y-%m-%d"), "", "4", "4"]
+
+        expect(@result[5]).to eql expected_results
+      end
+
+      it 'has has the correct data (row 5, day 2)' do
+        expected_results = [(@created_at + 1).strftime("%Y-%m-%d"), "", "4", "4"]
+
+        expect(@result[6]).to eql expected_results
+      end
+
+      it 'has has the correct data (row 6, day 3, translation day)' do
+        expected_results = [(@created_at + 2).strftime("%Y-%m-%d"), "", "0", "2"]
+
+        expect(@result[7]).to eql expected_results
+      end
+
+      it 'has has the correct data (row 7, day 4, day after translation)' do
+        expected_results = [(@created_at + 3).strftime("%Y-%m-%d"), "", "0", "2"]
+
+        expect(@result[8]).to eql expected_results
+        # these results are the same for every day after day 4 (day 4 - end_date)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the Backlog Report. It shows the total words that haven't been translated by day for a given date range. This has been rebased off the current master and should be an easy merge.