### PR TITLE
Filter out duplicate commits on homepage

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Square Inc.
+# Copyright 2014-2018 Square Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ class HomeController < ApplicationController
   # | `commits_filter__hide_exported`     | A string flag indicating whether exported Commits should be hidden or not: 'true', 'false'.                           |
   # | `commits_filter__hide_autoimported` | A string flag indicating whether auto imported Commits should be hidden or not: 'true', 'false'.                      |
   # | `commits_filter__show_only_mine`    | A string flag indicating whether only Commits from the current user should be shown: 'true', 'false'.                 |
+  # | `commits_filter__hide_duplicates`   | A string flag indicating whether only unique Commits should be shown (by fingerprint): 'true', 'false'.                 |
   # | `articles_filter__project_id`       | A Project ID to filter Articles by (default all Projects).                                                            |
   # | `articles_filter__name`             | A name to filter Articles by.                                                                                         |
 

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -107,10 +107,12 @@ class Commit < ActiveRecord::Base
     indexes :loading, type: 'boolean'
     indexes :ready, type: 'boolean'
     indexes :exported, type: 'boolean'
+    indexes :fingerprint, type: 'string'
+    indexes :duplicate, type: 'boolean'
   end
 
   def regular_index_fields
-    %w(project_id user_id priority due_date created_at revision ready exported loading)
+    %w(project_id user_id priority due_date created_at revision ready exported loading fingerprint duplicate)
   end
 
   def special_index_fields

--- a/app/services/home_index_items_finder.rb
+++ b/app/services/home_index_items_finder.rb
@@ -33,6 +33,7 @@ class HomeIndexItemsFinder
     hide_exported     = form[:commits_filter__hide_exported]
     hide_autoimported = form[:commits_filter__hide_autoimported]
     show_only_mine    = form[:commits_filter__show_only_mine]
+    hide_duplicates   = form[:commits_filter__hide_duplicates]
 
     # PAGINATION
     offset = form[:offset]
@@ -54,6 +55,7 @@ class HomeIndexItemsFinder
               must { exists field: :user_id } if hide_autoimported
               must { term user_id: 1 } if show_only_mine
               must { term loading: false }
+              must { term duplicate: false } if hide_duplicates
 
               case status
               when 'uncompleted'

--- a/app/support/home_index_form.rb
+++ b/app/support/home_index_form.rb
@@ -41,6 +41,7 @@ class HomeIndexForm
     set_commits_filter__hide_exported
     set_commits_filter__hide_autoimported
     set_commits_filter__show_only_mine
+    set_commits_filter__hide_duplicates
 
     # article specific
     set_articles_filter__name
@@ -128,6 +129,17 @@ class HomeIndexForm
           params[:commits_filter__show_only_mine] == 'true'
         elsif cookies[:home_index__commits_filter__show_only_mine]
           cookies[:home_index__commits_filter__show_only_mine] == 'true'
+        else
+          false
+        end
+  end
+
+  def set_commits_filter__hide_duplicates
+    vars[:commits_filter__hide_duplicates] = cookies[:home_index__commits_filter__hide_duplicates] =
+        if params[:commits_filter__hide_duplicates].present?
+          params[:commits_filter__hide_duplicates] == 'true'
+        elsif cookies[:home_index__commits_filter__hide_duplicates]
+          cookies[:home_index__commits_filter__hide_duplicates] == 'true'
         else
           false
         end

--- a/app/views/home/commits/_filter_bar.slim
+++ b/app/views/home/commits/_filter_bar.slim
@@ -28,6 +28,8 @@
     .collapse
       .control-group
         span.advanced-filters-label Advanced Filters:
+        = check_box_tag 'commits_filter__hide_duplicates', 'true', @form[:commits_filter__hide_duplicates]
+        | Hide duplicate commits
         = check_box_tag 'commits_filter__show_only_mine', 'true', @form[:commits_filter__show_only_mine]
         | Show only my commits
         = check_box_tag 'commits_filter__hide_exported', 'true', @form[:commits_filter__hide_exported]

--- a/app/workers/commit_importer.rb
+++ b/app/workers/commit_importer.rb
@@ -47,8 +47,8 @@ class CommitImporter
 
       # to eliminate duplicate commits (from things like `git -amend`),
       # we calculate a "fingerprint" for the commit based on it's commits_keys
-      # once the fingerprint is set, it will check for other duplicates
-      # based on the fingerprint and mark them as such.
+      # once the fingerprint is set, it will check for duplicates
+      # and that will decide if this commit is a duplicate.
       set_fingerprint_find_dupes(commit)
 
       # the readiness hooks were all disabled, so now we need to go through and calculate keys' readiness.
@@ -76,8 +76,8 @@ class CommitImporter
     def set_fingerprint_find_dupes(commit)
       commit.fingerprint = Digest::SHA1.hexdigest(commit.commits_keys.order(:key_id).pluck(:key_id).join(','))
 
-      # now that we have a fingerprint, look up others to mark them as duplicates
-      Commit.where(fingerprint: commit.fingerprint).update_all(duplicate: true)
+      # now that we have a fingerprint, look up others to mark this as a duplicate if the exist
+      commit.duplicate = Commit.where(fingerprint: commit.fingerprint).exists?
     end
   end
 

--- a/db/migrate/20180129223845_add_fingerprint_to_commits.rb
+++ b/db/migrate/20180129223845_add_fingerprint_to_commits.rb
@@ -1,0 +1,7 @@
+class AddFingerprintToCommits < ActiveRecord::Migration
+  def change
+    add_column :commits, :fingerprint, :string
+    add_column :commits, :duplicate, :boolean, default: false
+    add_index :commits, :fingerprint
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -252,6 +252,8 @@ CREATE TABLE commits (
     import_batch_id character varying,
     import_errors text,
     revision character varying(40) NOT NULL,
+    fingerprint character varying,
+    duplicate boolean DEFAULT false,
     CONSTRAINT commits_message_check CHECK ((char_length((message)::text) > 0)),
     CONSTRAINT commits_priority_check CHECK (((priority >= 0) AND (priority <= 3)))
 );
@@ -1230,6 +1232,13 @@ CREATE INDEX index_commits_keys_on_created_at ON commits_keys USING btree (creat
 
 
 --
+-- Name: index_commits_on_fingerprint; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_commits_on_fingerprint ON commits USING btree (fingerprint);
+
+
+--
 -- Name: index_commits_on_project_id_and_revision; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1833,4 +1842,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171024225818');
 INSERT INTO schema_migrations (version) VALUES ('20171103183318');
 
 INSERT INTO schema_migrations (version) VALUES ('20171206152825');
+
+INSERT INTO schema_migrations (version) VALUES ('20180129223845');
 

--- a/lib/tasks/commit_fingerprint.rake
+++ b/lib/tasks/commit_fingerprint.rake
@@ -1,0 +1,18 @@
+namespace :commit_fingerprint do
+  desc "Updates commits with a fingerprint of it's commits_keys"
+  task update: :environment do
+    puts "[commit_fingerprint:update] Updating fingerprints on commits."
+
+    Commit.includes(:commits_keys).order(created_at: :asc).all.each do |commit|
+      # calculate the new fingerprint
+      fingerprint = Digest::SHA1.hexdigest(commit.commits_keys.order(:key_id).pluck(:key_id).join(','))
+      # update all the other commits with the same fingerprint as duplicates
+      Commit.where(fingerprint: fingerprint).update_all(duplicate: true)
+      # save this commit with the fingerprint
+      commit.fingerprint = fingerprint
+      commit.save!
+    end
+
+    puts "[commit_fingerprint:update] Fingerprinting finished."
+  end
+end

--- a/lib/tasks/commit_fingerprint.rake
+++ b/lib/tasks/commit_fingerprint.rake
@@ -3,14 +3,20 @@ namespace :commit_fingerprint do
   task update: :environment do
     puts "[commit_fingerprint:update] Updating fingerprints on commits."
 
-    Commit.includes(:commits_keys).order(created_at: :asc).all.each do |commit|
+    Commit.includes(:commits_keys).all.each do |commit|
       # calculate the new fingerprint
       fingerprint = Digest::SHA1.hexdigest(commit.commits_keys.order(:key_id).pluck(:key_id).join(','))
-      # update all the other commits with the same fingerprint as duplicates
-      Commit.where(fingerprint: fingerprint).update_all(duplicate: true)
+
       # save this commit with the fingerprint
       commit.fingerprint = fingerprint
+      # assume this isn't a duplicate
+      commit.duplicate = false
       commit.save!
+
+      # update all commits except for the oldest with the same fingerprint as duplicates
+      duplicates = Commit.where(fingerprint: fingerprint).order(created_at: :asc).limit(1000).offset(1)
+      # this needs to be done in 2 steps because update_all doesn't take into account the offset
+      Commit.where(id: duplicates.map(&:id)).update_all(duplicate: true)
     end
 
     puts "[commit_fingerprint:update] Fingerprinting finished."

--- a/spec/factories/commits.rb
+++ b/spec/factories/commits.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     loading false
     ready false
     skip_import true
+    duplicate false
 
     after(:build) do |commit|
       class << commit; def set_author() end; end

--- a/spec/lib/tasks/commit_fingerprint_rake_spec.rb
+++ b/spec/lib/tasks/commit_fingerprint_rake_spec.rb
@@ -1,0 +1,63 @@
+# Copyright 2018 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'commit_fingerprint:update' do
+  subject { Rake::Task['commit_fingerprint:update'].execute }
+
+  before :all do
+    Rake.application.rake_require "tasks/commit_fingerprint"
+    Rake::Task.define_task(:environment)
+  end
+
+  it 'should calculate and save a fingerprint for each commit' do
+    commit = FactoryBot.create(:commit, fingerprint: nil)
+    key1 = FactoryBot.create(:key, commits: [commit])
+    key2 = FactoryBot.create(:key, commits: [commit])
+
+    subject
+
+    expected_fingerprint = Digest::SHA1.hexdigest([key1.id, key2.id].join(','))
+    commit.reload
+    expect(commit.fingerprint).to eq(expected_fingerprint)
+    expect(commit.duplicate).to be false
+  end
+
+  it 'should mark duplicate commits as such' do
+    key1 = FactoryBot.create(:key)
+    key2 = FactoryBot.create(:key)
+    expected_fingerprint = Digest::SHA1.hexdigest([key1.id, key2.id].join(','))
+
+    commit1 = FactoryBot.create(:commit)
+    commit2 = FactoryBot.create(:commit)
+
+    commit1.keys << key1
+    commit2.keys << key1
+
+    commit1.keys << key2
+    commit2.keys << key2
+
+    subject
+
+    commit1.reload
+    commit2.reload
+
+    expect(commit1.fingerprint).to eq(expected_fingerprint)
+    expect(commit2.fingerprint).to eq(expected_fingerprint)
+    expect(commit1.duplicate).to be true
+    expect(commit2.duplicate).to be false
+  end
+end

--- a/spec/lib/tasks/commit_fingerprint_rake_spec.rb
+++ b/spec/lib/tasks/commit_fingerprint_rake_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe 'commit_fingerprint:update' do
     expect(commit.duplicate).to be false
   end
 
-  it 'should mark duplicate commits as such' do
+  it 'should mark duplicate commits as such, keeping the oldest commit as active' do
     key1 = FactoryBot.create(:key)
     key2 = FactoryBot.create(:key)
     expected_fingerprint = Digest::SHA1.hexdigest([key1.id, key2.id].join(','))
 
-    commit1 = FactoryBot.create(:commit)
+    commit1 = FactoryBot.create(:commit) # oldest commit
     commit2 = FactoryBot.create(:commit)
 
     commit1.keys << key1
@@ -57,7 +57,7 @@ RSpec.describe 'commit_fingerprint:update' do
 
     expect(commit1.fingerprint).to eq(expected_fingerprint)
     expect(commit2.fingerprint).to eq(expected_fingerprint)
-    expect(commit1.duplicate).to be true
-    expect(commit2.duplicate).to be false
+    expect(commit1.duplicate).to be false
+    expect(commit2.duplicate).to be true
   end
 end

--- a/spec/workers/commit_importer_spec.rb
+++ b/spec/workers/commit_importer_spec.rb
@@ -112,5 +112,22 @@ RSpec.describe CommitImporter::Finisher do
       CommitImporter::Finisher.new.on_success true, 'commit_id' => @commit.id
       expect(@key.reload).to be_ready
     end
+
+    it "sets the commit's fingerprint" do
+      CommitImporter::Finisher.new.on_success true, 'commit_id' => @commit.id
+
+      expect(@commit.reload.fingerprint).to_not be_nil
+      expected_fingerprint = Digest::SHA1.hexdigest(@key.id.to_s)
+      expect(@commit.fingerprint).to eq expected_fingerprint
+    end
+
+    it "sets a duplicate commit as such" do
+      expected_fingerprint = Digest::SHA1.hexdigest(@key.id.to_s)
+      commit2 = FactoryBot.create(:commit, fingerprint: expected_fingerprint)
+
+      CommitImporter::Finisher.new.on_success true, 'commit_id' => @commit.id
+
+      expect(commit2.reload.duplicate).to be true
+    end
   end
 end


### PR DESCRIPTION
This change filters the duplicate commits from the homepage only. If these changes are acceptable, I will make changes to the reports to also filter out the duplicates.

To get started once deployed, you'll need to run the rake task `commit_fingerprint:update`. This sets fingerprints on all the records. While it's doing that, it will mark older commits that are duplicates as such. We went with the approach of marking duplicates to make filtering easier within ElasticSearch. Just using the fingerprint involved aggregates and those don't filter the main query. 