### PR TITLE
Filtered the backlog_report query significantly, and exclude duplicates.

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -121,8 +121,9 @@ class StatsController < ApplicationController
     begin
       start_date =  Date.strptime(params[:start_date], '%m/%d/%Y')
       end_date =  Date.strptime(params[:end_date], '%m/%d/%Y')
+      exclude_duplicates = params[:exclude_duplicates]
       filename = "backlog-report-#{start_date.strftime('%Y-%m-%d')}-to-#{end_date.strftime('%Y-%m-%d')}.csv"
-      send_data Reports::BacklogReport.generate_csv(start_date, end_date), filename: filename
+      send_data Reports::BacklogReport.generate_csv(start_date, end_date, exclude_duplicates), filename: filename
     rescue
       render text: t('stats.reports.failure'), status: 400
     end

--- a/app/views/stats/_date_fields.slim
+++ b/app/views/stats/_date_fields.slim
@@ -1,8 +1,8 @@
 .control-group
-  = label_tag :start_date
+  = label_tag :start_date, nil, class: 'control-label'
   .controls
     = text_field_tag :start_date, 1.month.ago.strftime('%m/%d/%Y') , class: 'datepicker form-control', required: true
 .control-group
-  = label_tag :end_date
+  = label_tag :end_date, nil, class: 'control-label'
   .controls
     = text_field_tag :end_date, Time.now.strftime('%m/%d/%Y'), class: 'datepicker form-control', required: true

--- a/app/views/stats/backlog_report.slim
+++ b/app/views/stats/backlog_report.slim
@@ -10,5 +10,10 @@ hr.dividers
 .translation_report
   = form_tag stats_generate_backlog_report_path(format: :csv)
     = render partial: 'stats/date_fields'
+    .control-group
+      .controls
+        label.control-label
+          = check_box_tag 'exclude_duplicates', 'true', true
+          | Hide Duplicate Commits
     .form-actions
       = submit_tag 'Get Report', class: 'btn btn-primary'

--- a/app/views/stats/translator_report.slim
+++ b/app/views/stats/translator_report.slim
@@ -11,14 +11,14 @@ hr.dividers
   = form_tag stats_generate_translator_report_path(format: :csv)
     = render partial: 'stats/date_fields'
     .control-group
-      = label_tag :languages
+      = label_tag :languages, nil, class: 'control-label'
       .controls
         - @languages.each do |language|
           label
             = check_box_tag 'languages[]', language, true
             = language.upcase
     .control-group
-      = label_tag :exclude_internal
+      = label_tag :exclude_internal, nil, class: 'control-label'
       .controls
           label
             = radio_button_tag :exclude_internal, true, true


### PR DESCRIPTION
This is a revision of the Backlog Report. It is now much faster. It should take around 20 seconds to run. I'm utilizing the database to do grouping and preliminary sums instead of doing them in Ruby. This lessens the time overall.