### PR TITLE
Changed update! to update so that exceptions don't occur.

### DIFF
--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -245,7 +245,7 @@ class Key < ActiveRecord::Base
       end
 
       finder = FuzzyMatchTranslationsFinder.new(source_copy, t)
-      t.update!(
+      t.update(
         tm_match: finder.top_fuzzy_match_percentage
       )
     end


### PR DESCRIPTION
A simple change to fix the exceptions found in production. I suspect the record that caused the exception is one already in the database that either was entered before this validation was added or was entered without going through Rails.

We have not been able to reproduce the exception, but this change uses `update` instead of `update!` to set the `tm_match` on creation.