### PR TITLE
Fixed bug with HashFields not saving to the database

### DIFF
--- a/app/assets/javascripts/application/multi_field.js.coffee
+++ b/app/assets/javascripts/application/multi_field.js.coffee
@@ -170,14 +170,17 @@ class root.HashField
     @options.renderer div, key, value
     key_field = div.find('[rel=key]')
     value_field = div.find('[rel=value]')
-    refreshName = =>
-      new_key = key_field.val()
+    refreshName = (locale) =>
+      new_key = key_field.val() || locale
       if new_key?.length > 0
         value_field.attr 'name', "#{this.name()}[#{new_key}]"
       else
         value_field.removeAttr 'name'
     key_field.keyup refreshName
     key_field.change refreshName
+    key_field.on 'typeahead:change', (evt, locale) =>
+      refreshName(locale)
+      
     refreshName()
 
     remove = $('<a/>').addClass('fa fa-minus-circle').attr('href', '#').appendTo(div)


### PR DESCRIPTION
This is a minor change. The HashField control wasn't updating the name of the value field correctly. The events `change` and `keyup` don't work correctly with typeahead.js. Ultimately the `refreshName` method should be rewritten, but I wasn't sure of the impact since there are no client-side JavaScript tests/specs. Thus, I fixed the issue by handling the correct event `typeahead:change` and passed in a variable to `refreshName`. If the textbox doesn't have a value (which was the issue), it will use the passed in value as the locale instead of pulling it from the key textbox. This shouldn't have any adverse effects due to the minor change.