### PR TITLE
Fixes the hide duplicates commit filter from sticking.

### DIFF
--- a/app/views/home/index.js.coffee.erb
+++ b/app/views/home/index.js.coffee.erb
@@ -103,6 +103,8 @@ $(window).ready () ->
   commits_filter_form.find('input#commits_filter__show_only_mine').change ->
     $.cookie 'home_index__commits_filter__show_only_mine', $(this).is(':checked')
 
+  commits_filter_form.find('input#commits_filter__hide_duplicates').change ->
+    $.cookie 'home_index__commits_filter__hide_duplicates', $(this).is(':checked')
 
   # ARTICLE SPECIFIC
 


### PR DESCRIPTION
This fixes the issue where users are unable to change the show/hide setting for duplicate commits on the home page.