### PR TITLE
Project translations report

### DIFF
--- a/lib/reports/project_translation_report.rb
+++ b/lib/reports/project_translation_report.rb
@@ -23,7 +23,7 @@ module Reports
       raise ArgumentError, 'end_date cannot be earlier than the start date' if end_date < start_date
 
       CSV.generate do |csv|
-        translations  = Translation.where(translation_date: start_date..end_date)
+        translations  = Translation.where(translation_date: start_date.beginning_of_day..end_date.end_of_day)
                                    .joins(key: :project)
                                    .group(['projects.name','translations.rfc5646_locale'])
                                    .count

--- a/lib/reports/project_translation_report.rb
+++ b/lib/reports/project_translation_report.rb
@@ -26,7 +26,7 @@ module Reports
         translations  = Translation.where(translation_date: start_date.beginning_of_day..end_date.end_of_day)
                                    .joins(key: :project)
                                    .group(['projects.name','translations.rfc5646_locale'])
-                                   .count
+                                   .sum(:words_count)
         languages = translations.keys.map {|k| k[1]}.uniq.sort
         empty_cols = Array.new(languages.count, '')
 

--- a/spec/lib/reports/project_translation_report_spec.rb
+++ b/spec/lib/reports/project_translation_report_spec.rb
@@ -36,16 +36,16 @@ RSpec.describe Reports::ProjectTranslationReport do
         @start_date = Date.today
         @end_date = @start_date.next_month
         @translation_date = @start_date.next_day
-        @expected_results = ['Foo', '3', '1', '2']
+        @expected_results = ['Foo', '6', '2', '4']
 
         project = FactoryBot.create(:project, name: 'Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
         key1 = FactoryBot.create(:key, project: project)
         key2 = FactoryBot.create(:key, project: project)
         key3 = FactoryBot.create(:key, project: project)
 
-        FactoryBot.create(:translation, key: key1, rfc5646_locale: 'fr', translation_date: @translation_date)
-        FactoryBot.create(:translation, key: key2, rfc5646_locale: 'it', translation_date: @translation_date)
-        FactoryBot.create(:translation, key: key3, rfc5646_locale: 'it', translation_date: @translation_date)
+        FactoryBot.create(:translation, key: key1, rfc5646_locale: 'fr', source_copy: 'foo bar', translation_date: @translation_date, tm_match: @match_percentage)
+        FactoryBot.create(:translation, key: key2, rfc5646_locale: 'it', source_copy: 'foo bar', translation_date: @translation_date, tm_match: @match_percentage)
+        FactoryBot.create(:translation, key: key3, rfc5646_locale: 'it', source_copy: 'foo bar', translation_date: @translation_date, tm_match: @match_percentage)
       end
 
       let(:report) { CSV.parse(Reports::ProjectTranslationReport.generate_csv(@start_date, @end_date)) }


### PR DESCRIPTION
These are revisions to the Project Translation Report. It now allows running a single day's worth of data. It also sums up the words_counts field instead of returning the count of translations.