### PR TITLE
Fix call to translated string in issue.rb

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -143,7 +143,7 @@ class Issue < ActiveRecord::Base
   # ===== END subscribed_emails =====
 
   def user_name
-    user.try!(:name) || t('models.issue.unknown_user')
+    user.try!(:name) || I18n.t('models.issue.unknown_user')
   end
 
   def self.order_default


### PR DESCRIPTION
Use of 't' outside of views must be called on I18n