### PR TITLE
Translator report revisions

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -97,7 +97,7 @@ class StatsController < ApplicationController
   end
 
   def translator_report
-    @languages = Project.pluck(:targeted_rfc5646_locales, :base_rfc5646_locale).map { |hash, base| hash.keys - [base]}.flatten.uniq.sort
+    @languages = Project.pluck(:targeted_rfc5646_locales, :base_rfc5646_locale).map { |hash, base| hash.keys - [base]}.flatten.map(&:downcase).uniq.sort
   end
 
   def generate_translator_report

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -97,7 +97,7 @@ class StatsController < ApplicationController
   end
 
   def translator_report
-    @languages = Project.pluck(:targeted_rfc5646_locales, :base_rfc5646_locale).map { |hash, base| hash.keys - [base]}.flatten.map(&:downcase).uniq.sort
+    @languages = Project.pluck(:targeted_rfc5646_locales, :base_rfc5646_locale).map { |hash, base| hash.keys - [base]}.flatten.uniq.sort
   end
 
   def generate_translator_report

--- a/config/environments/development/reports.yml
+++ b/config/environments/development/reports.yml
@@ -1,0 +1,1 @@
+internal_domains: ['@squareup.com']


### PR DESCRIPTION
This refactored version of the translator report fixes various issues, such as languages showing up twice in the list for selection. Also, a lot of a logic was moved to Postgres to speed up processing of the report.