### PR TITLE
Removed source column from the report to eliminate confusion.

### DIFF
--- a/lib/reports/project_translation_report.rb
+++ b/lib/reports/project_translation_report.rb
@@ -28,19 +28,17 @@ module Reports
                                    .group(['projects.name','translations.rfc5646_locale'])
                                    .sum(:words_count)
         languages = translations.keys.map {|k| k[1]}.uniq.sort
-        empty_cols = Array.new(languages.count, '')
+        empty_cols = Array.new(languages.count - 1, '')
 
         csv << ['Start Date', start_date] + empty_cols
         csv << ['End Date', end_date] + empty_cols
-        csv << ['', ''] + empty_cols
-        csv << ['Project', 'source'] + languages
+        csv << [''] + empty_cols
+        csv << ['Project'] + languages
 
         projects = translations.keys.map(&:first).uniq.sort
 
         projects.each do |project|
           row = [project]
-
-          row += [translations.select {|k,v| k[0] == project}.values.inject(:+) || 0]
 
           languages.each do |language|
             lang_total = translations[[project, language]] || 0

--- a/lib/reports/project_translation_report.rb
+++ b/lib/reports/project_translation_report.rb
@@ -32,7 +32,7 @@ module Reports
 
         csv << ['Start Date', start_date] + empty_cols
         csv << ['End Date', end_date] + empty_cols
-        csv << [''] + empty_cols
+        csv << ['', ''] + empty_cols
         csv << ['Project'] + languages
 
         projects = translations.keys.map(&:first).uniq.sort

--- a/spec/lib/reports/project_translation_report_spec.rb
+++ b/spec/lib/reports/project_translation_report_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Reports::ProjectTranslationReport do
         @start_date = Date.today
         @end_date = @start_date.next_month
         @translation_date = @start_date.next_day
-        @expected_results = ['Foo', '6', '2', '4']
+        @expected_results = ['Foo', '2', '4']
 
         project = FactoryBot.create(:project, name: 'Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
         key1 = FactoryBot.create(:key, project: project)
@@ -52,15 +52,15 @@ RSpec.describe Reports::ProjectTranslationReport do
 
       it 'has the expected start and end date' do
         expected_results = [
-          ["Start Date", @start_date.strftime("%Y-%m-%d"), "", ""],
-          ["End Date", @end_date.strftime("%Y-%m-%d"), "", ""]
+          ["Start Date", @start_date.strftime("%Y-%m-%d"), ""],
+          ["End Date", @end_date.strftime("%Y-%m-%d"), ""]
         ]
 
         expect(report[0..1]).to eql expected_results
       end
 
       it 'has the row headers' do
-        expected_results = ["Project", "source", "fr", "it"]
+        expected_results = ["Project", "fr", "it"]
 
         expect(report[3]).to eql expected_results
       end


### PR DESCRIPTION
A straightforward change, just removed the source column from the report to eliminate confusion.