### PR TITLE
Update Export Method Not Defeined button.

### DIFF
--- a/app/views/commits/_layout.slim
+++ b/app/views/commits/_layout.slim
@@ -25,7 +25,7 @@
           data-tooltip-position-at='bottom middle'
           data-tooltip-position-my='top middle'
         ]
-          | Missing Format
+          | Export Format Not Defined
         .tooltip#missing_format_tooltip
           | You must set a default manifest format to use this feature
       - else


### PR DESCRIPTION
When a project does not have the export manifest format defined,
commits from this Project do not support manifests downloading.

Showing Missing Manifest in this case causes confusion. Update
the button to Export Format Not Defined.