### PR TITLE
Unlock after job has run rather than before starting

### DIFF
--- a/lib/sidekiq_locking.rb
+++ b/lib/sidekiq_locking.rb
@@ -24,8 +24,9 @@ module SidekiqLocking
 
   # @private
   def perform_with_locking(*args)
-    self.class.unlock *args
     perform_without_locking *args
+  ensure
+    self.class.unlock *args
   end
 
   module ClassMethods


### PR DESCRIPTION
This changes the locking behavior to prevent the same job being queued until the first one has finished, rather than until started. I think this behavior makes more sense and won't break anything, and without this change I think the touchdown sidekiq worker I added yesterday will end up stacking and holding up the whole queue.