### PR TITLE
Backlog report revisions

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -121,9 +121,8 @@ class StatsController < ApplicationController
     begin
       start_date =  Date.strptime(params[:start_date], '%m/%d/%Y')
       end_date =  Date.strptime(params[:end_date], '%m/%d/%Y')
-      exclude_duplicates = params[:exclude_duplicates]
       filename = "backlog-report-#{start_date.strftime('%Y-%m-%d')}-to-#{end_date.strftime('%Y-%m-%d')}.csv"
-      send_data Reports::BacklogReport.generate_csv(start_date, end_date, exclude_duplicates), filename: filename
+      send_data Reports::BacklogReport.generate_csv(start_date, end_date), filename: filename
     rescue
       render text: t('stats.reports.failure'), status: 400
     end

--- a/app/views/stats/backlog_report.slim
+++ b/app/views/stats/backlog_report.slim
@@ -10,10 +10,5 @@ hr.dividers
 .translation_report
   = form_tag stats_generate_backlog_report_path(format: :csv)
     = render partial: 'stats/date_fields'
-    .control-group
-      .controls
-        label.control-label
-          = check_box_tag 'exclude_duplicates', 'true', true
-          | Hide Duplicate Commits
     .form-actions
       = submit_tag 'Get Report', class: 'btn btn-primary'

--- a/lib/reports/backlog_report.rb
+++ b/lib/reports/backlog_report.rb
@@ -14,7 +14,7 @@
 
 module Reports
   module BacklogReport
-    def self.generate_csv(start_date, end_date, exclude_duplicates = true)
+    def self.generate_csv(start_date, end_date)
       # verify that the params are dates
       raise ArgumentError, 'start_date is not a date' unless start_date.instance_of?(Date)
       raise ArgumentError, 'end_date is not a date' unless end_date.instance_of?(Date)
@@ -23,7 +23,7 @@ module Reports
       raise ArgumentError, 'end_date cannot be earlier than the start date' if end_date < start_date
 
       CSV.generate do |csv|
-        translations  = retrieve_translations(start_date, end_date, exclude_duplicates)
+        translations  = retrieve_translations(start_date, end_date)
 
         languages = translations.map(&:rfc5646_locale).uniq.sort
         lang_count = languages.count
@@ -56,22 +56,12 @@ module Reports
       end
     end
 
-    def self.retrieve_translations(start_date, end_date, exclude_duplicates = true)
+    def self.retrieve_translations(start_date, end_date)
       translations = Translation.where('rfc5646_locale != source_rfc5646_locale')
                                 .where('created_at <= ?', end_date)
                                 .where('(translation_date >= ? OR translation_date is null)', start_date)
-                                .where('(tm_match < 70.0 OR tm_match is null)')
+                                .where('(tm_match < 60.0 OR tm_match is null)')
                                 .group('DATE(created_at), DATE(translation_date), rfc5646_locale')
-
-      if exclude_duplicates
-        translations = translations.where('NOT EXISTS(
-            SELECT 1
-            FROM translations AS t
-            INNER JOIN commits_keys AS ck ON ck.key_id = t.key_id
-            INNER JOIN commits AS c ON c.id = ck.commit_id
-            WHERE (c.duplicate = TRUE AND t.id = translations.id)
-          )')
-      end
 
       translations.select('DATE(created_at) as created_at', 'DATE(translation_date) as translation_date', :rfc5646_locale, 'SUM(words_count) as words')
     end

--- a/spec/lib/reports/backlog_report_spec.rb
+++ b/spec/lib/reports/backlog_report_spec.rb
@@ -114,40 +114,14 @@ RSpec.describe Reports::BacklogReport do
         expect(results.all.length).to eq 0
       end
 
-      it 'should filter out records with a greater than 70% tm_match' do
+      it 'should filter out records with a less than 60% tm_match' do
         start_date = Date.today
         end_date = start_date.next_month
         created_at = start_date.next_day
 
-        FactoryBot.create(:translation, created_at: created_at, translation_date: nil, tm_match: 78)
+        FactoryBot.create(:translation, created_at: created_at, translation_date: nil, tm_match: 68)
         results = Reports::BacklogReport.send :retrieve_translations, start_date, end_date
         expect(results.all.length).to eq 0
-      end
-
-      it 'should filter out translations that are associated with a duplicate commit' do
-        start_date = Date.today
-        end_date = start_date.next_month
-        created_at = start_date.next_day
-
-        key = FactoryBot.create(:key)
-        FactoryBot.create(:commit, duplicate: true, keys: [key])
-        FactoryBot.create(:translation, key: key, created_at: created_at, translation_date: nil)
-
-        results = Reports::BacklogReport.send :retrieve_translations, start_date, end_date
-        expect(results.all.length).to eq 0
-      end
-
-      it 'should not filter out translations that are associated with a duplicate commit if exclude_duplicates is false' do
-        start_date = Date.today
-        end_date = start_date.next_month
-        created_at = start_date.next_day
-
-        key = FactoryBot.create(:key)
-        FactoryBot.create(:commit, duplicate: true, keys: [key])
-        FactoryBot.create(:translation, key: key, created_at: created_at, translation_date: nil)
-
-        results = Reports::BacklogReport.send :retrieve_translations, start_date, end_date, false
-        expect(results.all.length).to eq 1
       end
     end
   end


### PR DESCRIPTION
I have revised the backlog report, eliminating the hide duplicates option. During our testing, we didn't find any duplicate commits with distinct keys on them, so this option isn't needed. Also, I changed the `tm_match` percentage check to 60% instead of 70%. I will be putting in a new PR to hopefully speed up the report. Last I knew, it was still running far too slow.