### PR TITLE
Handle both lowercase and uppercase letters in octal while importin…

### DIFF
--- a/lib/importer/android.rb
+++ b/lib/importer/android.rb
@@ -132,7 +132,7 @@ module Importer
             result << "\t"
           elsif scanner.scan(/@/)
             result << '@'
-          elsif (match = scanner.scan(/u[0-9a-f]{4}/))
+          elsif (match = scanner.scan(/u[0-9a-fA-F]{4}/))
             result << Integer("0x#{match[1..-1]}").chr('utf-8')
           else
             raise "Invalid escape sequence at position #{scanner.pos} in #{string.inspect}"

--- a/spec/lib/importer/android_spec.rb
+++ b/spec/lib/importer/android_spec.rb
@@ -101,4 +101,17 @@ RSpec.describe Importer::Android do
       expect(@project.keys.for_key('/java/basic-hdpi/strings.xml:leading_newline').first.translations.find_by_rfc5646_locale('en-US').copy).to eql('Hello')
     end
   end
+
+  describe "#unescape" do
+    before :each do
+      @project = FactoryBot.create(:project, base_rfc5646_locale: 'en')
+      @commit = FactoryBot.create(:commit, project: @project)
+      @blob = FactoryBot.create(:fake_blob, project: @project)
+    end
+
+    it "should unescape strings properly" do
+      expect(Importer::Android.new(@blob, @commit).send(:unescape, '\\u003A 1 min left on break')).to eql(': 1 min left on break');
+      expect(Importer::Android.new(@blob, @commit).send(:unescape, '\\u003a 1 min left on break')).to eql(': 1 min left on break');
+    end
+  end
 end


### PR DESCRIPTION
During import Android strings, if a string failed to unescape, the Importer::Android throws. All following keys will not be added to translations. The Shuttle reports it succeeds while some translations are missed.