### PR TITLE
Don't retry touchdown worker jobs

### DIFF
--- a/app/workers/branch_touchdowner.rb
+++ b/app/workers/branch_touchdowner.rb
@@ -14,7 +14,7 @@
 
 class BranchTouchdowner
   include Sidekiq::Worker
-  sidekiq_options queue: :low
+  sidekiq_options queue: :low, retry: false
 
   # Executes this worker.
   #


### PR DESCRIPTION
Retries are not subject to the SidekiqLocking logic which means failures end up stacking up. Without a retry the cronjob will queue this again anyway