### PR TITLE
Fails the shuttle request when sha is missing.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -246,14 +246,20 @@ class ProjectsController < ApplicationController
   # | `type`    | Whether it was a pull request or push that triggered it  |
 
   def stash_webhook
-    if @project.git?
-      revision = params[:sha]
-      other_fields = { description: 'Requested due to a Pull Request on Stash.' }
-      CommitCreator.perform_once @project.id, revision, other_fields: other_fields
-      render status: :ok, text: 'Success'
-    else
+    unless @project.git?
       render status: :bad_request, text: 'Repository url is blank'
+      return
     end
+
+    revision = params[:sha]
+    if revision.blank?
+      render status: :bad_request, text: 'SHA is blank'
+      return
+    end
+
+    other_fields = { description: 'Requested due to a Pull Request on Stash.' }
+    CommitCreator.perform_once @project.id, revision, other_fields: other_fields
+    render status: :ok, text: 'Success'
   end
 
   # Shows a page were admins can configure settings to mass copy translations from one locale to another.

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -200,6 +200,12 @@ RSpec.describe ProjectsController do
       post :stash_webhook, { id: project.to_param, sha: "HEAD" }
       expect(response.status).to eql(400)
     end
+
+    it "returns 400 if SHA is missing" do
+      project = FactoryBot.create(:project, repository_url: Rails.root.join('spec', 'fixtures', 'repository.git').to_s)
+      post :stash_webhook, { id: project.to_param, sha: "" }
+      expect(response.status).to eql(400)
+    end
   end
 
   describe "#setup_mass_copy_translations" do


### PR DESCRIPTION
Or the commit will be retried and always failed with
Failed to parse revision specifier - Invalid pattern ''