### PR TITLE
Change tm match percentage

### DIFF
--- a/lib/reports/incoming_new_words_report.rb
+++ b/lib/reports/incoming_new_words_report.rb
@@ -45,7 +45,7 @@ module Reports
           row += [translations.select {|t| t.created_at == date}.sum(&:words_count) || 0]
 
           languages.each do |language|
-            new_words = translations.select{|t| t.tm_match < 70 && t.rfc5646_locale == language && t.created_at == date }
+            new_words = translations.select{|t| t.tm_match < 60 && t.rfc5646_locale == language && t.created_at == date }
 
             lang_total = new_words.sum(&:words_count) || 0
             row += [lang_total]

--- a/lib/reports/project_translation_report.rb
+++ b/lib/reports/project_translation_report.rb
@@ -28,6 +28,7 @@ module Reports
                                    .group(['projects.name','translations.rfc5646_locale'])
                                    .sum(:words_count)
         languages = translations.keys.map {|k| k[1]}.uniq.sort
+        return if languages.count == 0
         empty_cols = Array.new(languages.count - 1, '')
 
         csv << ['Start Date', start_date] + empty_cols

--- a/spec/lib/reports/incoming_new_words_report_spec.rb
+++ b/spec/lib/reports/incoming_new_words_report_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Reports::IncomingNewWordsReport do
       end
 
       it 'has the expected data for the timeframe' do
-        expected_results = [@created_at.strftime('%Y-%m-%d'), '8', '4', '2']
+        expected_results = [@created_at.strftime('%Y-%m-%d'), '8', '4', '0']
 
         expect(@result[5]).to eql expected_results
       end


### PR DESCRIPTION
This, along with the backlog report PR, changes the tm_match of the reports to 60% from 70%. Also, I've fixed the spec error when there are no languages found. Both changes are fairly simple.