### PR TITLE
Translator Report - Articles

### DIFF
--- a/app/models/translation_change.rb
+++ b/app/models/translation_change.rb
@@ -31,6 +31,7 @@ class TranslationChange < ActiveRecord::Base
   belongs_to :translation, inverse_of: :translation_changes
   belongs_to :user
   belongs_to :project
+  belongs_to :article
 
   serialize :diff, Hash
 
@@ -46,6 +47,8 @@ class TranslationChange < ActiveRecord::Base
     if diff.present?
       project_id = Project.joins(:slugs).where('slugs.slug = ?', params[:project_id]).pluck('projects.id').first
       commit = (params[:commit] == 'Save') ? nil : params[:commit]
+      article_id = params[:article_id] || translation.article&.id
+
       TranslationChange.create(
         translation: translation,
         user: translation.modifier,
@@ -54,6 +57,7 @@ class TranslationChange < ActiveRecord::Base
         is_edit: is_edit,
         tm_match: translation.tm_match,
         sha: commit,
+        article_id: article_id,
         project_id: project_id
       )
     end

--- a/db/migrate/20180525005743_add_article_to_translation_changes.rb
+++ b/db/migrate/20180525005743_add_article_to_translation_changes.rb
@@ -1,0 +1,5 @@
+class AddArticleToTranslationChanges < ActiveRecord::Migration
+  def change
+    add_reference :translation_changes, :article, index: true, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -696,7 +696,6 @@ CREATE TABLE translation_changes (
     user_id integer,
     diff text,
     tm_match numeric,
-    sha character varying,
     sha character varying(40),
     role character varying,
     project_id integer,
@@ -1837,4 +1836,3 @@ INSERT INTO schema_migrations (version) VALUES ('20180129223845');
 INSERT INTO schema_migrations (version) VALUES ('20180506023840');
 
 INSERT INTO schema_migrations (version) VALUES ('20180525005743');
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -701,6 +701,8 @@ CREATE TABLE translation_changes (
     role character varying,
     project_id integer,
     is_edit boolean DEFAULT false
+    is_edit boolean DEFAULT false,
+    article_id integer
 );
 
 
@@ -1833,4 +1835,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171206152825');
 INSERT INTO schema_migrations (version) VALUES ('20180129223845');
 
 INSERT INTO schema_migrations (version) VALUES ('20180506023840');
+
+INSERT INTO schema_migrations (version) VALUES ('20180525005743');
 

--- a/spec/lib/reports/translator_report_spec.rb
+++ b/spec/lib/reports/translator_report_spec.rb
@@ -53,14 +53,17 @@ RSpec.describe Reports::TranslatorReport do
         @languages = ['it', 'fr']
 
         @project = FactoryBot.create(:project, name: 'Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
+        @article_project = FactoryBot.create(:project, name: 'Article Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
         @commit = FactoryBot.create(:commit, project: @project)
         @reviewer = FactoryBot.create(:user, :reviewer, approved_rfc5646_locales: %w(it fr), first_name: 'Mark', email: 'mark@test.host')
         @translator = FactoryBot.create(:user, :translator, approved_rfc5646_locales: %w(it fr), first_name: 'Rebecca')
+        @article = FactoryBot.create(:article, project: @article_project, created_at: @start_date)
 
         key1 = FactoryBot.create(:key, project: @project)
         key2 = FactoryBot.create(:key, project: @project)
         key3 = FactoryBot.create(:key, project: @project)
         key4 = FactoryBot.create(:key, project: @project)
+        key5 = FactoryBot.create(:key, project: @article_project)
         @commit.keys << [key1, key2, key3, key4]
 
         t1 = FactoryBot.create(:translation, key: key1, rfc5646_locale: 'fr', tm_match: 71, source_copy: 'One two three', translation_date: @start_date, review_date: @start_date, reviewer: @reviewer, translator: @translator)
@@ -73,11 +76,14 @@ RSpec.describe Reports::TranslatorReport do
 
         t3 = FactoryBot.create(:translation, key: key3, rfc5646_locale: 'it', tm_match: 50, source_copy: 'One two three', translation_date: @end_date, review_date: nil, reviewer: nil, translator: @translator)
         FactoryBot.create(:translation_change, translation: t3, project: @project, sha: @commit.revision, is_edit: false, user: @translator, role: 'translator', created_at: @end_date, tm_match: t3.tm_match)
-        FactoryBot.create(:translation_change, translation: t3, project: @project, sha: @commit.revision, is_edit: true, user: @reviewer, role: 'reviewer', created_at: @end_date, tm_match: t3.tm_match)
 
-        t4 =FactoryBot.create(:translation, key: key4, rfc5646_locale: 'it', tm_match: 90, source_copy: 'One two three', translation_date: @end_date, review_date: @end_date, reviewer: @reviewer, translator: @translator)
+        t4 = FactoryBot.create(:translation, key: key4, rfc5646_locale: 'it', tm_match: 90, source_copy: 'One two three', translation_date: @end_date, review_date: @end_date, reviewer: @reviewer, translator: @translator)
         FactoryBot.create(:translation_change, translation: t4, project: @project, sha: @commit.revision, is_edit: false, user: @translator, role: 'translator', created_at: @end_date, tm_match: t4.tm_match)
         FactoryBot.create(:translation_change, translation: t4, project: @project, sha: @commit.revision, is_edit: true, user: @reviewer, role: 'reviewer', created_at: @end_date, tm_match: t4.tm_match)
+
+        t5 = FactoryBot.create(:translation, key: key5, rfc5646_locale: 'it', tm_match: 60, source_copy: 'One two three', translation_date: @end_date, review_date: @end_date, reviewer: @reviewer, translator: @translator)
+        FactoryBot.create(:translation_change, translation: t5, project: @article_project, sha: nil, article: @article, is_edit: false, user: @translator, role: 'translator', created_at: @end_date, tm_match: t5.tm_match)
+        FactoryBot.create(:translation_change, translation: t5, project: @article_project, sha: nil, article: @article, is_edit: true, user: @reviewer, role: 'reviewer', created_at: @end_date, tm_match: t5.tm_match)
       end
 
       context 'header info' do
@@ -85,85 +91,102 @@ RSpec.describe Reports::TranslatorReport do
 
         it 'has the expected start and end date' do
           expected_results = [
-            ["Start Date", @start_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", ""],
-            ["End Date", @end_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", ""]
+            ["Start Date", @start_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", ""],
+            ["End Date", @end_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", ""]
           ]
           expect(result[0..1]).to eql expected_results
         end
 
         it 'has the expected languages' do
-          expected_results = ["Language(s)", "FR, IT", "", "", "", "", "", "", "", "", ""]
+          expected_results = ["Language(s)", "FR, IT", "", "", "", "", "", "", "", "", "", "", ""]
           expect(result[2]).to eql expected_results
         end
 
         it 'has the expected column headers' do
-          expected_results = ["Date", "User", "Role", "Language (Locale)", "Project Name", "Job Name (SHA)", "New Words", "60-69%", "70-79%%", "80-89%", "90-99%", "100%"]
+          expected_results = ["Date", "User", "Role", "Language (Locale)", "Project Name", "Job Name (SHA)", "Article Name", "Article Date", "New Words", "60-69%", "70-79%%", "80-89%", "90-99%", "100%"]
           expect(result[5]).to eql expected_results
         end
       end
 
       context 'data for timeframe' do
+        let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages)) }
 
         it 'has the expected row 6' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    'reviewer',   'FR', project, sha, '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    'reviewer',   'FR', project, sha, '', '', '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'FR', project, sha, '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'FR', project, sha, '', '', '0', '0', '3', '0', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    'reviewer',   'IT', project, sha, '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    'reviewer',   'IT', project, sha, '', '', '0', '0', '0', '3', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT', project, sha, '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT', project, sha, '', '', '0', '0', '0', '3', '0', '0']
           expect(result[9]).to eql expected_results
         end
 
         it 'has the expected row 10' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    'reviewer',   'IT',   project, sha, '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    'reviewer',   'IT',   @article_project.name, '', article, @article.created_at.strftime("%Y-%m-%d"), '0', '3', '0', '0', '0', '0']
           expect(result[10]).to eql expected_results
         end
 
         it 'has the expected row 11' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT',   project, sha, '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT',   @article_project.name, '', article, @article.created_at.strftime("%Y-%m-%d"), '0', '3', '0', '0', '0', '0']
           expect(result[11]).to eql expected_results
         end
 
         it 'has the expected row 12' do
-          expect(result[12]).to eql nil
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    'reviewer',   'IT',   project, sha, '', '', '0', '0', '0', '0', '3', '0']
+          expect(result[12]).to eql expected_results
+        end
+
+        it 'has the expected row 13' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT',   project, sha, '', '', '3', '0', '0', '0', '3', '0']
+          expect(result[13]).to eql expected_results
+        end
+
+        it 'has the expected row 14' do
+          expect(result[14]).to eql nil
         end
       end
 
       context 'internal users' do
+        let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, true)) }
 
         it 'has the expected row 6' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'FR', project, sha, '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'FR', project, sha, '', '', '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT', project, sha, '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT', project, sha, '', '', '0', '0', '0', '3', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT',   project, sha, '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT',   @article_project.name, '', article, @article.created_at.strftime("%Y-%m-%d"), '0', '3', '0', '0', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expect(result[9]).to eql nil
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', 'translator', 'IT',   project, sha, '', '', '3', '0', '0', '0', '3', '0']
+          expect(result[9]).to eql expected_results
+        end
+
+        it 'has the expected row 10' do
+          expect(result[10]).to eql nil
         end
       end
     end

--- a/spec/requests/translations_spec.rb
+++ b/spec/requests/translations_spec.rb
@@ -22,6 +22,32 @@ RSpec.describe "Translations", type: :request do
       expect(TranslationChange.first.sha).to eq commit
     end
 
+    it 'handles an article from search' do
+      project = FactoryBot.create(:project, targeted_rfc5646_locales: {'fr'=>true, 'es'=>true}, base_rfc5646_locale: 'en')
+      article = FactoryBot.create(:article, project: project)
+      section = FactoryBot.create(:section, article: article, active: true)
+      key1 = FactoryBot.create(:key, key: "firstkey", project: project, section: section)
+      translation = FactoryBot.create(:translation, source_rfc5646_locale: 'en', source_copy: 'fake', copy: nil, approved: nil, key: key1)
+      url = project_key_translation_path(project, key1, translation.to_param)
+      patch_via_redirect url, translation: { copy: 'fake' }
+
+      expect(response).to render_template(:edit)
+      expect(TranslationChange.first.article).to eq article
+    end
+
+    it 'handles an article in the params' do
+      project = FactoryBot.create(:project, targeted_rfc5646_locales: {'fr'=>true, 'es'=>true}, base_rfc5646_locale: 'en')
+      key1 = FactoryBot.create(:key, key: "firstkey",  project: project)
+      article = FactoryBot.create(:article)
+      translation = FactoryBot.create(:translation, source_rfc5646_locale: 'en', source_copy: 'fake', copy: nil, approved: nil, key: key1)
+
+      url = project_key_translation_path(project, key1, translation.to_param, article_id: article.id)
+      patch_via_redirect url, translation: { copy: 'fake' }
+
+      expect(response).to render_template(:edit)
+      expect(TranslationChange.first.article).to eq article
+    end
+
     it 'handles a project in the params' do
       project = FactoryBot.create(:project, targeted_rfc5646_locales: {'fr'=>true, 'es'=>true}, base_rfc5646_locale: 'en')
       key1 = FactoryBot.create(:key, key: "firstkey",  project: project)
@@ -37,7 +63,7 @@ RSpec.describe "Translations", type: :request do
       key1 = FactoryBot.create(:key, key: "firstkey",  project: project)
       translation = FactoryBot.create(:translation, source_rfc5646_locale: 'en', source_copy: 'fake', copy: nil, approved: nil, key: key1)
       url = project_key_translation_path(project, key1, translation.to_param)
-      expect{ patch_via_redirect url, translation: { copy: 'fake' } }.to change{ TranslationChange.count }.by(1) 
+      expect{ patch_via_redirect url, translation: { copy: 'fake' } }.to change{ TranslationChange.count }.by(1)
     end
   end
 end


### PR DESCRIPTION
This change adds the article name and created_at dates to the Translator Report. It also fixes a bug with the Travis CI build where the `SHA` is in the `structure.sql` file twice, causing many specs to fail.