### PR TITLE
Fix a bug that caused MultiFields to delete all items when changing locale or key filters

### DIFF
--- a/app/assets/javascripts/application/multi_field.js.coffee
+++ b/app/assets/javascripts/application/multi_field.js.coffee
@@ -45,7 +45,7 @@ class root.ArrayField
     observer = new MutationObserver (changes) =>
       for change in changes
         do (change) =>
-          if change.attributeName == 'name'
+          if change.attributeName == 'data-name'
             @element.find('[name]').attr('name', "#{this.name()}[]")
     observer.observe @element[0], {attributes: true}
 
@@ -56,7 +56,7 @@ class root.ArrayField
     this.drawButton()
     for string in @value
       do (string) => this.addElement string
-      
+
     if @value.length == 0
       this.addElement()
 
@@ -69,16 +69,16 @@ class root.ArrayField
     div = $('<div/>').addClass('arrayfield-element').insertBefore(@new_element_button)
 
     @options.renderer div, "#{this.name()}[]", value
-    
+
     $.each @element.find(".arrayfield-element"), (index, element) =>
       text_field = $(element).find("input[type='text']").unbind("keypress")
       if $(element).is(":last-of-type")
         text_field.keypress (e) =>
           if e.which == 13 || e.which == 9
-            this.addElement @options.defaultValue  
+            this.addElement @options.defaultValue
             $(element).next().find("input[type='text']").focus()
             return false
-      else 
+      else
         text_field.keypress (e) =>
           if e.which == 13 || e.which == 9
             $(element).next().find("input[type='text']").focus()
@@ -105,7 +105,7 @@ class root.ArrayField
     @new_element_button.appendTo(button_div)
 
   # @private
-  name: -> @element.attr 'name'
+  name: -> @element.attr 'data-name'
 
 # A dynamic field that builds a list of field item pairs (with plus and minus
 # buttons) that will be serialized as a hash in Rails. This allows the field
@@ -154,7 +154,7 @@ class root.HashField
     this.drawButtons()
     for own name, value of @value
       do (name, value) => this.addElement name, value
-    
+
     if Object.keys(@value).length == 0
       this.addElement @options.defaultKey, @options.defaultValue
 
@@ -167,7 +167,7 @@ class root.HashField
   addElement: (key, value) ->
     div = $('<div/>').addClass('hashfield-element').insertBefore(@element.find('>.multifield-last-element'))
 
-    @options.renderer div, key, value
+    @options.renderer div, key, value, this
     key_field = div.find('[rel=key]')
     value_field = div.find('[rel=value]')
     refreshName = (locale) =>
@@ -180,7 +180,7 @@ class root.HashField
     key_field.change refreshName
     key_field.on 'typeahead:change', (evt, locale) =>
       refreshName(locale)
-      
+
     refreshName()
 
     remove = $('<a/>').addClass('fa fa-minus-circle').attr('href', '#').appendTo(div)

--- a/app/views/projects/_form.js.coffee.erb
+++ b/app/views/projects/_form.js.coffee.erb
@@ -28,8 +28,7 @@ $(document).ready () ->
 
   setupKeyFields = () ->
     $('#project_key_locale_exclusions, #project_key_locale_inclusions').hashField(
-      renderer: (container, key, value) ->
-
+      renderer: (container, key, value, hash_field) ->
         key_field = $('<div/>').addClass('hashfield-key').appendTo(container)
         value_field = $('<div/>').addClass('hashfield-multi-value').appendTo(container)
 
@@ -43,7 +42,11 @@ $(document).ready () ->
             .addClass('locale-field').appendTo(key_field)
         )
 
-        valueField = $('<div/>').attr({rel: 'value', 'data-value': JSON.stringify(value)}).addClass('array-field').appendTo(value_field);
+        valueField = $('<div/>').attr(
+          rel:          'value',
+          'data-value': JSON.stringify(value),
+          'data-name':  "#{hash_field.name()}[#{key}]"
+        ).addClass('array-field').appendTo(value_field)
         valueField.arrayField(
           renderer: (container, name, value) ->
             $('<input/>').attr(
@@ -99,7 +102,7 @@ $(document).ready () ->
     setupLocaleField()
     setupKeyFields()
     setupPathFields()
-  else 
+  else
     $(document).bind('locales_loaded', setupLocaleField)
     $(document).bind('locales_loaded', setupKeyFields)
     $(document).bind('locales_loaded', setupPathFields)

--- a/config/initializers/multifield.rb
+++ b/config/initializers/multifield.rb
@@ -54,6 +54,7 @@ class ActionView::Helpers::Tags::ContentField < ActionView::Helpers::Tags::Base
     options['value'] = options.fetch('value'){ value_before_type_cast(object) }
     options['value'] &&= ERB::Util.html_escape(options['value'])
     add_default_name_and_id(options)
+    options['data-name'] = options['name']
     tag(options['tag_name'].to_s, options, true) + "</#{options['tag_name']}>".html_safe
   end
 end


### PR DESCRIPTION
Using the `name` attribute on `DIV` tags is unreliable; use `data-name` instead