### PR TITLE
Major translator report revisions and enhancements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ gem 'find_or_create_on_scopes'
 gem 'rails-observers'
 gem 'after-commit-on-action'
 
+# REPORTING
+gem 'postgres_ext'
+gem 'active_record_union'
+
 # ElASTICSEARCH
 gem 'elasticsearch', '< 6.0'
 gem 'elasticsearch-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_record_union (1.3.0)
+      activerecord (>= 4.0)
     activejob (4.2.10)
       activesupport (= 4.2.10)
       globalid (>= 0.3.0)
@@ -237,8 +239,13 @@ GEM
     orm_adapter (0.5.0)
     parslet (1.8.1)
     pg (0.21.0)
+    pg_array_parser (0.0.9)
     pivot_table (1.0.0)
     popper_js (1.12.9)
+    postgres_ext (3.0.1)
+      activerecord (~> 4.0)
+      arel (>= 4.0.1)
+      pg_array_parser (~> 0.0.9)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -416,6 +423,7 @@ PLATFORMS
 
 DEPENDENCIES
   CFPropertyList
+  active_record_union
   after-commit-on-action
   autoprefixer-rails
   aws-sdk (< 3)
@@ -458,6 +466,7 @@ DEPENDENCIES
   parslet
   pg (< 1.0)
   pivot_table
+  postgres_ext
   pry-byebug
   rack-cache
   rails (= 4.2.10)

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Square Inc.
+# Copyright 2014-2018 Square Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ require 'fileutils'
 # | `loading`          | If `true`, there is at least one {BlobImporter} processing this Commit.                                  |
 # | `priority`         | An administrator-set priority arbitrarily defined as a number between 0 (highest) and 3 (lowest).        |
 # | `due_date`         | A date displayed to translators and reviewers informing them of when the Commit must be fully localized. |
-# | `completed_at`     | The date this Commit completed translation.                                                              |
+# | `approved _at`     | The date this Commit completed translation and has been approved.                                                              |
 # | `description`      | A user-submitted description of why we are localizing this commit.                                       |
 # | `pull_request_url` | A user-submitted URL to the pull request that is being localized.                                        |
 # | `import_batch_id`  | The ID of the Sidekiq batch of import jobs.                                                              |
@@ -138,7 +138,7 @@ class Commit < ActiveRecord::Base
   validates :due_date,
             timeliness: {type: :date},
             allow_nil:  true
-  validates :completed_at,
+  validates :approved_at,
             timeliness: {type: :date},
             allow_nil:  true
 
@@ -197,11 +197,11 @@ class Commit < ActiveRecord::Base
 
   # Calculates the value of the `ready` field and saves the record.
   # If this is the first time a commit has been marked as ready, sets
-  # completed_at to be the current time.
+  # approved_at to be the current time.
 
   def recalculate_ready!
     self.ready = successfully_loaded? && keys_are_ready? && !errored_during_import?
-    self.completed_at = Time.current if self.ready && self.completed_at.nil?
+    self.approved_at = Time.current if self.ready && self.approved_at.nil?
     index_elasticsearch_document
     save!
   end

--- a/app/views/commits/_layout.slim
+++ b/app/views/commits/_layout.slim
@@ -39,7 +39,7 @@
     strong
       - if @commit.loading?
         - if @commit.import_batch_status
-          - current_status = "Loading With #{pluralize_with_delimiter @commit.import_batch_status.pending, 'Job'} Remaining" 
+          - current_status = "Loading With #{pluralize_with_delimiter @commit.import_batch_status.pending, 'Job'} Remaining"
         - else
           - current_status = "Hung (Loading, No Import Batch)"
       - elsif @commit.ready?
@@ -52,8 +52,8 @@
       span.separator &nbsp;/&nbsp;
       = "Found #{@commit.keys.count} Keys"
       span.separator &nbsp;/&nbsp;
-      - if @commit.completed_at
-        = "First Completed #{time_ago_in_words(@commit.completed_at)} ago"
+      - if @commit.approved_at
+        = "First Completed #{time_ago_in_words(@commit.approved_at)} ago"
       - elsif @commit.loaded_at
         = "First Loaded #{time_ago_in_words(@commit.loaded_at)} ago"
       - else

--- a/app/views/stats/translator_report.slim
+++ b/app/views/stats/translator_report.slim
@@ -18,6 +18,16 @@ hr.dividers
             = check_box_tag 'languages[]', language, true
             = language.upcase
     .control-group
+      = label_tag :report_type, nil, class: 'control-label'
+      .controls
+          label
+            = radio_button_tag :report_type, 'standard', true
+            | Translations or reviews completed in the date range
+          label
+            = radio_button_tag :report_type, 'completed', false
+            | Projects completed in the date range
+
+    .control-group
       = label_tag :exclude_internal, nil, class: 'control-label'
       .controls
           label

--- a/db/migrate/20180722180453_change_completed_at_to_approved_at.rb
+++ b/db/migrate/20180722180453_change_completed_at_to_approved_at.rb
@@ -1,0 +1,5 @@
+class ChangeCompletedAtToApprovedAt < ActiveRecord::Migration
+  def change
+    rename_column :commits, :completed_at, :approved_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -236,7 +236,7 @@ CREATE TABLE public.commits (
     due_date date,
     priority integer,
     user_id integer,
-    completed_at timestamp without time zone,
+    approved_at timestamp without time zone,
     exported boolean DEFAULT false NOT NULL,
     loaded_at timestamp without time zone,
     description text,
@@ -1923,3 +1923,4 @@ INSERT INTO schema_migrations (version) VALUES ('20180525005743');
 
 INSERT INTO schema_migrations (version) VALUES ('20180608004859');
 
+INSERT INTO schema_migrations (version) VALUES ('20180722180453');

--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -14,7 +14,7 @@
 
 module Reports
   module TranslatorReport
-    def self.generate_csv(start_date, end_date, languages, exclude_internal = false)
+    def self.generate_csv(start_date, end_date, languages, exclude_internal = false, report_type = 'standard')
       # verify that the params are dates
       raise ArgumentError, 'start_date is not a date' unless start_date.instance_of?(Date)
       raise ArgumentError, 'end_date is not a date' unless end_date.instance_of?(Date)
@@ -27,50 +27,21 @@ module Reports
       # and that languages is an array
       raise ArgumentError, 'languages must be an array' unless languages.kind_of?(Array)
 
-      empty_cols = Array.new(13, '')
-      internal_domains = Shuttle::Configuration.reports.internal_domains.join('|')
+      empty_cols = Array.new(14, '')
 
       CSV.generate do |csv|
-        translator_query = TranslationChange.where('translation_changes.created_at': start_date.beginning_of_day..end_date.end_of_day)
-                                      .where('translation_changes.tm_match IS NOT NULL')
-                                      .where('translations.rfc5646_locale': languages)
-                                      .joins(:project, :user, :translation)
-                                      .joins('LEFT OUTER JOIN articles ON articles.id = article_id')
-                                      .joins('LEFT OUTER JOIN commits ON commits.revision = sha')
-                                      .group('DATE(translation_changes.created_at), rfc5646_locale, translation_changes.role, projects.name, articles.name, first_name, users.id, sha, classification, DATE(articles.created_at)')
-                                      .order('group_id', 'rfc5646_locale', 'projects.name', 'first_name', 'classification')
-                                      .select('RANK() OVER (
-                                                 ORDER BY DATE(translation_changes.created_at), rfc5646_locale, projects.name, sha, articles.name, first_name
-                                              ) AS group_id,
-                                              DATE(translation_changes.created_at) as "date",
-                                              users.first_name,
-                                              users.id as user_id,
-                                              translation_changes.role,
-                                              rfc5646_locale,
-                                              projects.name as project_name,
-                                              sha,
-                                              articles.name as article_name,
-                                              DATE(articles.created_at) as article_date,
-                                              CASE
-                                                WHEN translation_changes.tm_match < 60 THEN 0
-                                                WHEN translation_changes.tm_match >= 60 AND translation_changes.tm_match < 70 THEN 1
-                                                WHEN translation_changes.tm_match >= 70 AND translation_changes.tm_match < 80 THEN 2
-                                                WHEN translation_changes.tm_match >= 80 AND translation_changes.tm_match < 90 THEN 3
-                                                WHEN translation_changes.tm_match >= 90 AND translation_changes.tm_match < 100 THEN 4
-                                                WHEN translation_changes.tm_match = 100 THEN 5
-                                              END AS classification,
-                                              MAX(commits.created_at) as job_start,
-                                              SUM(words_count) as words_count')
-
-
-        translator_query = translator_query.where("users.email ~ '^(?!.*(#{internal_domains})$).*$'") if exclude_internal
+        if report_type == 'completed'
+          translator_query = get_completion_query(start_date, end_date, languages, exclude_internal)
+        else
+          translator_query = get_standard_query(start_date, end_date, languages, exclude_internal)
+        end
 
         csv << ['Start Date', start_date] + empty_cols
         csv << ['End Date', end_date] + empty_cols
         csv << ['Language(s)', "#{languages.sort.join(", ").upcase}"] + empty_cols
         csv << ['', ''] + empty_cols
-        csv << ['Translator Report', ''] + empty_cols
-        csv << ['Date', 'User', 'User Id', 'Role', 'Language (Locale)', 'Project Name', 'Job Name (SHA)', 'Job Start', 'Article Name', 'Article Date', 'New Words', '60-69%', '70-79%%', '80-89%', '90-99%', '100%']
+        csv << ['Translator Report', report_type.titlecase] + empty_cols
+        csv << ['Date', 'User', 'User Id', 'Role', 'Source Language', 'Language (Locale)', 'Project Name', 'Job Name (SHA)', 'Article Name', 'Job Start', 'Approval Date', 'New Words', '60-69%', '70-79%%', '80-89%', '90-99%', '100%']
 
         translator_query.group_by(&:group_id).each do |group, records|
           tc = records.first
@@ -81,12 +52,84 @@ module Reports
             counts[rec.classification] = rec.words_count
           end
           article = (tc.article_name || '')
-          article_date = (tc.article_date ? tc.article_date.strftime('%Y-%m-%d') : '')
           sha = (tc.sha || '')
-          job_start = (tc.job_start ? tc.job_start.in_time_zone.strftime('%Y-%m-%d %H:%M %:z') : '')
-          csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.rfc5646_locale.upcase, tc.project_name, sha, job_start, article, article_date, counts].flatten
+          job_start = (tc.job_start ? tc.job_start.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
+          approved_at = (tc.approved_at ? tc.approved_at.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
+          csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.source_rfc5646_locale.upcase, tc.rfc5646_locale.upcase, tc.project_name, sha, article, job_start, approved_at, counts].flatten
         end
       end
     end
+
+    def self.add_shared(query, languages, exclude_internal)
+      if exclude_internal
+        internal_domains = Shuttle::Configuration.reports.internal_domains.join('|')
+        query = query.where("users.email ~ '^(?!.*(#{internal_domains})$).*$'")
+      end
+
+      query.where('translation_changes.tm_match IS NOT NULL')
+           .where('translations.rfc5646_locale': languages)
+           .joins(:project, :user, :translation)
+           .group('source_rfc5646_locale, rfc5646_locale, translation_changes.role, projects.name, first_name, users.id, classification')
+           .select('users.first_name,
+                   users.id as user_id,
+                   translation_changes.role,
+                   source_rfc5646_locale,
+                   rfc5646_locale,
+                   projects.name as project_name,
+                   -- the following take the tm_match and converts it to a number 0-5
+                   CASE WHEN translation_changes.tm_match < 60 THEN 0 ELSE FLOOR((translation_changes.tm_match - 50)/10) END as classification,
+                   SUM(words_count) as words_count')
+    end
+
+    def self.get_standard_query(start_date, end_date, languages, exclude_internal)
+      query = TranslationChange.where('translation_changes.created_at': start_date.beginning_of_day..end_date.end_of_day)
+        .joins('LEFT OUTER JOIN articles ON articles.id = article_id')
+        .joins('LEFT OUTER JOIN commits ON commits.revision = sha')
+        .group('DATE(translation_changes.created_at)')
+        .group('articles.name, sha')
+        .order('group_id', 'rfc5646_locale', 'source_rfc5646_locale', 'projects.name', 'first_name', 'classification')
+        .select('RANK() OVER (
+                   ORDER BY DATE(translation_changes.created_at), rfc5646_locale, projects.name, sha, articles.name, first_name
+                 ) AS group_id,
+                 DATE(translation_changes.created_at) as "date",
+                 sha,
+                 articles.name as article_name,
+                 COALESCE(MIN(commits.created_at), MIN(articles.created_at)) as job_start,
+                 COALESCE(MAX(commits.approved_at), MAX(articles.first_completed_at)) as approved_at')
+      add_shared(query, languages, exclude_internal)
+    end
+
+    def self.get_completion_query(start_date, end_date, languages, exclude_internal)
+      commit_query = TranslationChange.where('commits.approved_at': start_date.beginning_of_day..end_date.end_of_day)
+        .joins('JOIN commits ON commits.revision = sha')
+        .group('DATE(commits.approved_at), sha')
+        .select('DATE(commits.approved_at) as "date",
+                sha,
+                NULL as article_name,
+                MIN(commits.created_at) as job_start,
+                MAX(commits.approved_at) as approved_at')
+      commit_query = add_shared(commit_query, languages, exclude_internal)
+
+      article_query = TranslationChange.where('articles.first_completed_at': start_date.beginning_of_day..end_date.end_of_day)
+        .joins('JOIN articles ON articles.id = article_id')
+        .group('DATE(articles.first_completed_at), articles.name')
+        .select('DATE(articles.first_completed_at) as "date",
+                 NULL,
+                 articles.name as article_name,
+                 MIN(articles.created_at) as job_start,
+                 MAX(articles.first_completed_at) as approved_at')
+      article_query = add_shared(article_query, languages, exclude_internal)
+
+      TranslationChange.from_cte('foo', commit_query.union(article_query))
+                       .select('RANK() OVER (
+                          ORDER BY date, rfc5646_locale, project_name, sha, article_name, first_name
+                        ) AS group_id, *')
+                       .order('group_id', 'rfc5646_locale', 'source_rfc5646_locale', 'project_name', 'first_name', 'classification')
+    end
+
+
+    private_class_method :get_standard_query
+    private_class_method :get_completion_query
+    private_class_method :add_shared
   end
 end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -21,7 +21,7 @@ namespace :metrics do
     date_range = date...(date + 1.day)
 
     commits_loaded = Commit.includes(:project).where(loaded_at: date_range)
-    commits_completed = Commit.includes(:project).where(completed_at: date_range)
+    commits_completed = Commit.includes(:project).where(approved_at: date_range)
 
     translations_created = Translation.not_base.where(created_at: date_range)
     # Proxy for now.  Will require a "completed at" field for Translation in future

--- a/spec/lib/reports/translator_report_spec.rb
+++ b/spec/lib/reports/translator_report_spec.rb
@@ -49,15 +49,15 @@ RSpec.describe Reports::TranslatorReport do
     describe 'CSV Data' do
       before do
         @start_date = Date.today
-        @end_date = @start_date.next_day
+        @end_date = @start_date.next_month
         @languages = ['it', 'fr']
 
         @project = FactoryBot.create(:project, name: 'Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
         @article_project = FactoryBot.create(:project, name: 'Article Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
-        @commit = FactoryBot.create(:commit, project: @project)
+        @commit = FactoryBot.create(:commit, project: @project, approved_at: @end_date)
         @reviewer = FactoryBot.create(:user, :reviewer, approved_rfc5646_locales: %w(it fr), first_name: 'Mark', email: 'mark@test.host')
         @translator = FactoryBot.create(:user, :translator, approved_rfc5646_locales: %w(it fr), first_name: 'Rebecca')
-        @article = FactoryBot.create(:article, project: @article_project, created_at: @start_date)
+        @article = FactoryBot.create(:article, project: @article_project, created_at: @start_date, first_completed_at: @end_date)
 
         key1 = FactoryBot.create(:key, project: @project)
         key2 = FactoryBot.create(:key, project: @project)
@@ -91,19 +91,19 @@ RSpec.describe Reports::TranslatorReport do
 
         it 'has the expected start and end date' do
           expected_results = [
-            ["Start Date", @start_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", ""],
-            ["End Date", @end_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", ""]
+            ["Start Date", @start_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", "", ""],
+            ["End Date", @end_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
           ]
           expect(result[0..1]).to eql expected_results
         end
 
         it 'has the expected languages' do
-          expected_results = ["Language(s)", "FR, IT", "", "", "", "", "", "", "", "", "", "", "", "", ""]
+          expected_results = ["Language(s)", "FR, IT", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
           expect(result[2]).to eql expected_results
         end
 
         it 'has the expected column headers' do
-          expected_results = ["Date", "User", "User Id", "Role", "Language (Locale)", "Project Name", "Job Name (SHA)", "Job Start", "Article Name", "Article Date", "New Words", "60-69%", "70-79%%", "80-89%", "90-99%", "100%"]
+          expected_results = ["Date", "User", "User Id", "Role", "Source Language", "Language (Locale)", "Project Name", "Job Name (SHA)", "Article Name", "Job Start", "Approval Date", "New Words", "60-69%", "70-79%%", "80-89%", "90-99%", "100%"]
           expect(result[5]).to eql expected_results
         end
       end
@@ -112,46 +112,48 @@ RSpec.describe Reports::TranslatorReport do
         let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
-        let!(:job_date) { @commit.created_at.strftime('%Y-%m-%d %H:%M %:z') }
+        let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages)) }
 
         it 'has the expected row 6' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",    'reviewer',   'FR', project, sha, job_date, '', '', '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",    'reviewer',  'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'FR', project, sha, job_date, '', '', '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'IT', project, sha, job_date, '', '', '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",     'reviewer', 'EN-US', 'IT', project, sha, '', commit_start, approved_at,'0', '0', '0', '3', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'IT', project, sha, job_date, '', '', '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '0', '0', '0', '3', '0', '0']
           expect(result[9]).to eql expected_results
         end
 
         it 'has the expected row 10' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'IT',   @article_project.name, '', '', article, @article.created_at.strftime("%Y-%m-%d"), '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer', 'EN-US', 'IT',  @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[10]).to eql expected_results
         end
 
         it 'has the expected row 11' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'IT',   @article_project.name, '', '', article, @article.created_at.strftime("%Y-%m-%d"), '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",     'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[11]).to eql expected_results
         end
 
         it 'has the expected row 12' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'IT',   project, sha, job_date, '', '', '0', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '0', '0', '0', '0', '3', '0']
           expect(result[12]).to eql expected_results
         end
 
         it 'has the expected row 13' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'IT',   project, sha, job_date, '', '', '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '3', '0', '0', '0', '3', '0']
           expect(result[13]).to eql expected_results
         end
 
@@ -164,31 +166,105 @@ RSpec.describe Reports::TranslatorReport do
         let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
-        let!(:job_date) { @commit.created_at.strftime('%Y-%m-%d %H:%M %:z') }
+        let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, true)) }
 
         it 'has the expected row 6' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'FR', project, sha, job_date, '', '', '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'IT', project, sha, job_date, '', '', '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '0', '0', '0', '3', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'IT',   @article_project.name, '', '', article, @article.created_at.strftime("%Y-%m-%d"), '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'IT',   project, sha, job_date, '', '', '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '3', '0', '0', '0', '3', '0']
           expect(result[9]).to eql expected_results
         end
 
         it 'has the expected row 10' do
           expect(result[10]).to eql nil
+        end
+      end
+
+      context 'completion date version' do
+        let!(:article) { @article.name }
+        let!(:project) { @project.name }
+        let!(:sha) { @commit.revision }
+        let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
+        let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, false, 'completed')) }
+
+        it 'has the expected row 6' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",    'reviewer',  'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expect(result[6]).to eql expected_results
+        end
+
+        it 'has the expected row 7' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expect(result[7]).to eql expected_results
+        end
+
+        it 'has the expected row 8' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer', 'EN-US', 'IT',  @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expect(result[8]).to eql expected_results
+        end
+
+        it 'has the expected row 9' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",     'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expect(result[9]).to eql expected_results
+        end
+
+        it 'has the expected row 10' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '0', '0', '0', '3', '3', '0']
+          expect(result[10]).to eql expected_results
+        end
+
+        it 'has the expected row 11' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expect(result[11]).to eql expected_results
+        end
+
+        it 'has the expected row 12' do
+          expect(result[12]).to eql nil
+        end
+      end
+      context 'completion date version: exclude internal users' do
+        let!(:article) { @article.name }
+        let!(:project) { @project.name }
+        let!(:sha) { @commit.revision }
+        let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
+        let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
+        let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, true, 'completed')) }
+
+        it 'has the expected row 6' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expect(result[6]).to eql expected_results
+        end
+
+        it 'has the expected row 7' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expect(result[7]).to eql expected_results
+        end
+
+        it 'has the expected row 8' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expect(result[8]).to eql expected_results
+        end
+
+        it 'has the expected row 9' do
+          expect(result[9]).to  eql nil
         end
       end
     end

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe Commit do
       expect(@commit.loaded_at.to_time).to eql(@created_at + 3.hours)
     end
 
-    it "should persist the completed_at time" do
-      expect(@commit.completed_at.to_time).to eql(@created_at + 6.hours)
+    it "should persist the approved_at time" do
+      expect(@commit.approved_at.to_time).to eql(@created_at + 6.hours)
     end
   end
 
@@ -173,7 +173,7 @@ RSpec.describe Commit do
       @project = FactoryBot.create(:project, repository_url: Rails.root.join('spec', 'fixtures', 'repository.git').to_s)
       @commit  = @project.commit!('HEAD', skip_import: true)
       @commit.keys.each(&:destroy)
-      @commit.update_attribute(:completed_at, nil)
+      @commit.update_attribute(:approved_at, nil)
     end
 
     context "has never loaded" do
@@ -207,7 +207,7 @@ RSpec.describe Commit do
         expect(@commit).not_to be_ready
       end
 
-      it "completed_at should remain nil if not ready" do
+      it "approved_at should remain nil if not ready" do
         @commit.keys << FactoryBot.create(:key)
         @commit.keys << FactoryBot.create(:key)
         FactoryBot.create(:translation, copy: nil, key: @commit.keys.last)
@@ -215,7 +215,7 @@ RSpec.describe Commit do
 
         @commit.recalculate_ready!
         expect(@commit).not_to be_ready
-        expect(@commit.completed_at).to be_nil
+        expect(@commit.approved_at).to be_nil
       end
 
       it "should set ready to true for commits with all ready keys" do
@@ -229,7 +229,7 @@ RSpec.describe Commit do
         expect(@commit).to be_ready
       end
 
-      it "should set completed_at to current time when ready" do
+      it "should set approved_at to current time when ready" do
         Timecop.freeze(Time.now)
         start_time = Time.now
 
@@ -239,22 +239,22 @@ RSpec.describe Commit do
         @commit.recalculate_ready!
         expect(@commit).to be_ready
 
-        expect(@commit.completed_at).to eql(start_time + 1.day)
+        expect(@commit.approved_at).to eql(start_time + 1.day)
         Timecop.return
       end
 
-      it "should not change completed_at if commit goes from ready to unready." do
+      it "should not change approved_at if commit goes from ready to unready." do
         @commit.keys << FactoryBot.create(:key)
         @commit.recalculate_ready!
         expect(@commit).to be_ready
-        completed_time = @commit.completed_at
+        completed_time = @commit.approved_at
 
         FactoryBot.create(:translation, copy: nil, key: @commit.keys.last)
         @commit.keys.last.recalculate_ready!
         @commit.recalculate_ready!
 
         expect(@commit).not_to be_ready
-        expect(@commit.completed_at).to eql(completed_time)
+        expect(@commit.approved_at).to eql(completed_time)
       end
 
       it "should not set ready if there are import errors in postgres" do

--- a/spec/models/observers/commit_observer_spec.rb
+++ b/spec/models/observers/commit_observer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CommitObserver do
         end
 
         it "does not send an email if the commit was previously ready" do
-          @commit = FactoryBot.create(:commit, loading: true, loaded_at: nil, user: FactoryBot.create(:user), completed_at: 1.day.ago)
+          @commit = FactoryBot.create(:commit, loading: true, loaded_at: nil, user: FactoryBot.create(:user), approved_at: 1.day.ago)
           ActionMailer::Base.deliveries.clear
           @commit.loading = false
           @commit.save!


### PR DESCRIPTION
This PR encompasses quite a few features, revisions, and enhancements for the Translator Report. 

1. I renamed the Commit's `completed_at` attribute to `approved_at` based on our meeting. For this round, I didn't touch Articles because I wasn't sure which attributes to change. This change isn't specific to the report, but something we talked about doing. (JIRA Task: SHTL-78)
2. The Translator Report now contains a "Source Language" column. (JIRA Task: SHTL-33)
3. I revised the "Job Start" column on the report to include the start date for Articles; this was left out of the last PR. (JIRA Task: SHTL-49)
4. The most significant change has to do with adding a new report option to filter based on the Job Approval Date instead of the standard Translation Change Date. For the Job Approval date, I'm using Commit's renamed column, `approved_at`. For Articles, I'm currently using the `first_completed_at` attribute. I'm not sure this is correct as the Article has a `last_completed_at` attribute. If this is, in fact, incorrect, I will alter the report to use the correct field. This task also involved adding a new Report Type option to the form that is used to generate the report. (JIRA Tasks: SHTL-52, SHTL-82)
5. The final change is a bunch of refactoring to keep the Translator Report DRY.