### PR TITLE
Add backend APIs to manage article groups.

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -1,0 +1,256 @@
+# Copyright 2015 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# This api can be consumed by external applications or internal views to
+# allow users to create/update/view Groups.
+#
+# If there is an `api_token`, the request will be authenticated via that token;
+# otherwise, it will be authenticated via session using the `authenticate_user!`
+# method that's used everywhere else in the application.
+
+module API
+  module V1
+    class GroupsController < ApplicationController
+      respond_to :json, only: [:index, :create, :update, :destroy]
+
+      skip_before_filter :authenticate_user!,        if: :api_request?
+      skip_before_action :verify_authenticity_token, if: :api_request?
+      before_filter :authenticate_with_api_token!,   if: :api_request?
+
+      before_filter :find_project
+      before_filter :find_group, only: [:show, :update, :destroy]
+
+      # EXTERNAL ONLY
+      #
+      # Returns all Groups in the Project.
+      #
+      # Routes
+      # ------
+      #
+      # * `/api/v1/projects/:project_id/groups(.format)?api_token=:api_token`
+      #
+      # Path/Url Parameters
+      # -------------------
+      #
+      # |              |                              |
+      # |:-------------|:-----------------------------|
+      # | `project_id` | The id of a Project.         |
+      # | `api_token`  | The api token for a Project. |
+
+      def index
+        respond_with @project do |format|
+          format.json { render json: decorate_groups }
+        end
+      end
+
+      # Creates a Group in a Project.
+      #
+      # Routes
+      # ------
+      #
+      # * `POST /api/v1/projects/:project_id/groups(.format)(?api_token=:api_token)`
+      #
+      # Path/Url Parameters
+      # ---------------
+      #
+      # |              |                                                                                         |
+      # |:-------------|:----------------------------------------------------------------------------------------|
+      # | `project_id` | The id of a Project.                                                                    |
+      # | `api_token`  | The api token for a Project. Not required if the request is coming from internal views. |
+      #
+      # Body Parameters
+      # ---------------
+      #
+      # |                   |                                                                                                               |
+      # |:------------------|:----------------------------------------|
+      # | `name`            | The name of the group.                  |
+      # | `article_names`   | The list of article names in the group  |
+      #
+      # Returns
+      # -------
+      # a map from article names to their readiness
+
+      def create
+        if group_exists?(params[:name])
+          render_error_with_message(t('controllers.api.v1.groups.group_found'), :bad_request)
+          return
+        end
+
+        group = @project.groups.new(name: params[:name])
+        errors = update_article_groups(group, params[:article_names])
+        if errors
+          render_errors(errors)
+          return
+        end
+
+        respond_with @project do |format|
+          format.json { render json: decorate_group(group) }
+        end
+      end
+
+      # Returns a Group.
+      #
+      # Routes
+      # ------
+      #
+      # * `GET /api/v1/projects/:project_id/groups/:name(.format)(?api_token=:api_token)`
+      #
+      # Path/Url Parameters
+      # ---------------
+      #
+      # |              |                                                                                         |
+      # |:-------------|:----------------------------------------------------------------------------------------|
+      # | `project_id` | The id of a Project.                                                                    |
+      # | `api_token`  | The api token for a Project. Not required if the request is coming from internal views. |
+      # | `name`       | The `name` of the group.                                                                |
+      #
+      # Returns
+      # -------
+      # a map from article names to their readiness
+
+      def show
+        respond_with @project do |format|
+          format.json { render json: decorate_group(@group) }
+        end
+      end
+
+      # Updates a Group in a Project.
+      #
+      # Routes
+      # ------
+      #
+      # * `PATCH /api/v1/projects/:project_id/groups/:name(.format)(?api_token=:api_token)`
+      # * `PUT /api/v1/projects/:project_id/groups/:name(.format)(?api_token=:api_token)`
+      #
+      # Path/Url Parameters
+      # ---------------
+      #
+      # |              |                                                                                         |
+      # |:-------------|:----------------------------------------------------------------------------------------|
+      # | `project_id` | The id of a Project.                                                                    |
+      # | `api_token`  | The api token for a Project. Not required if the request is coming from internal views. |
+      # | `name`       | The `name` of the Group.                                                                |
+      #
+      # Body Parameters
+      # ---------------
+      #
+      # |                   |                                                                                                               |
+      # |:------------------|:----------------------------------------|
+      # | `article_names`   | The list of article names in the group  |
+      #
+      # Returns
+      # -------
+      # a map from article names to their readiness
+
+      def update
+        errors = update_article_groups(@group, params['article_names'])
+        if errors
+          render_errors(errors)
+          return
+        end
+
+        respond_with @project do |format|
+          format.json { render json: decorate_group(@group) }
+        end
+      end
+
+      def destroy
+        @group.destroy
+
+        respond_with @project do |format|
+          format.json { render json: { status: true } }
+        end
+      end
+
+      # private
+
+      # ===== START AUTHENTICATION/AUTHORIZATION/VALIDATION ============================================================
+      def authenticate_with_api_token!
+        unless Project.where(id: params[:project_id], api_token: params[:api_token]).exists?
+          render_error_with_message(t('controllers.api.v1.groups.invalid_api_token'), :unauthorized)
+        end
+      end
+
+      def find_project
+        @project = Project.find_by_id(params[:project_id])
+
+        unless @project
+          render_error_with_message(t('controllers.api.v1.groups.project_not_found'), :not_found)
+        end
+      end
+
+      def find_group
+        @group = Group.find_by_name(params[:name])
+
+        unless @group
+          render_error_with_message(t('controllers.api.v1.groups.group_not_found'), :not_found)
+        end
+      end
+
+      def api_request?
+        params[:api_token].present?
+      end
+
+      # ===== END AUTHENTICATION/AUTHORIZATION/VALIDATION ==============================================================
+
+      # ===== START DECORATORS =========================================================================================
+      def decorate_groups
+        @project.groups.map(&:name).sort
+      end
+
+      def decorate_group(group)
+        group.article_groups.includes(:article).order(:index_in_group).map do |article_group|
+          {
+              name: article_group.article.name,
+              ready: article_group.article.ready?
+          }
+        end
+      end
+      # ===== END DECORATORS ===========================================================================================
+
+      def group_exists?(name)
+        @project.groups.where(name: name).count > 0
+      end
+
+      def render_error_with_message(message, status)
+        render_errors([{ message: message }], status)
+      end
+
+      def render_errors(errors, status=:bad_request)
+        respond_with(nil) do |format|
+          format.json { render json: { error: { errors: errors } }, status: status }
+        end
+      end
+
+      def update_article_groups(group, article_names)
+        errors = []
+        article_groups = params['article_names'].each_with_index.map do |article_name, index|
+          article = @project.articles.where(name: article_name).first
+          if article
+            ArticleGroup.new(group: group, article: article, index_in_group: index)
+          else
+            errors << t('controllers.api.v1.groups.article_not_found', article_name: article_name)
+          end
+        end
+        if errors.present?
+          return errors
+        end
+
+        group.article_groups = article_groups
+        group.save!
+        nil
+      end
+    end
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -89,6 +89,9 @@ class Article < ActiveRecord::Base
   has_many :translations, through:    :keys
   has_many :issues,       through:    :translations
 
+  has_many :article_groups, inverse_of: :article, dependent: :destroy
+  has_many :groups, through: :article_groups
+
   # Scopes
   scope :hidden, -> { where(hidden: true) }
   scope :showing, -> { where(hidden: false) }

--- a/app/models/article_group.rb
+++ b/app/models/article_group.rb
@@ -1,0 +1,29 @@
+# Copyright 2014 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# Join table between {Article} and {Group}.
+#
+# Associations
+# ------------
+#
+# |           |                                   |
+# |:----------|:----------------------------------|
+# | `article` | The {Article} found in the Group. |
+# | `group`   | The {Group} with the Article.     |
+
+# Represents the relationship between articles and their groups.
+class ArticleGroup < ActiveRecord::Base
+  belongs_to :group, inverse_of: :article_groups
+  belongs_to :article, inverse_of: :article_groups
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,72 @@
+# Copyright 2015 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# Represents a group of {Article Articles}, and provides a thin layer of abstraction over them.
+#
+# Name uniqueness
+# --------------
+#
+# The `name` field of Group is treated as a unique identifier within a Project.
+#
+# Associations
+# ============
+#
+# |                |                                                            |
+# |:---------------|:-----------------------------------------------------------|
+# | `project`      | The {Project} this Group belongs to                        |
+# | `articles`     | The {Article Articless} that belong to this Group          |
+#
+# Fields
+# ======
+#
+# |                             |                                                                                                                   |
+# |:----------------------------|:------------------------------------------------------------------------------------------------------------------|
+# | `name`                      | The unique identifier for this Group. This will be a user input in most cases.                                    |
+# | `description`               | A user submitted description. Can be used to provide context or instructions.                                     |
+# | `email`                     | The email address that should be used for communications.                                                         |
+# | `ready`                     | `true` when every required Translation under this Article has been approved.                                      |
+# | `priority`                  | An priority defined as a number between 0 (highest) and 3 (lowest).                                               |
+# | `due_date`                  | A date displayed to translators and reviewers informing them of when the Group must be fully localized.           |
+
+class Group < ActiveRecord::Base
+  extend SetNilIfBlank
+  set_nil_if_blank :description, :due_date, :priority
+
+  belongs_to :creator,    class_name: 'User'
+  belongs_to :updater,    class_name: 'User'
+  belongs_to :project,    inverse_of: :groups
+
+  has_many :article_groups, inverse_of: :group, dependent: :destroy
+  has_many :articles, through: :article_groups
+
+  # Scopes
+  scope :hidden, -> { where(hidden: true) }
+  scope :showing, -> { where(hidden: false) }
+  scope :ready, -> { where(ready: true) }
+  scope :not_ready, -> { where(ready: false) }
+  scope :loading, -> { where(loading: true) }
+
+  attr_readonly :project_id
+
+  validates :project, presence: true, strict: true
+  validates :name, presence: true, uniqueness: {scope: :project_id}
+  validates :name, exclusion: { in: %w(new) } # this word is reserved because it collides with new_group_path.
+  validates :description, length: {maximum: 2000}, allow_nil: true
+  validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }, allow_nil: true
+  validates :ready,   inclusion: { in: [true, false] }, strict: true
+  validates :priority, numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 3}, allow_nil: true
+  validates :due_date, timeliness: {type: :date}, allow_nil: true
+
+  def to_param() name end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,6 +41,7 @@ require 'file_mutex'
 # | `translations` | The {Translation Translations} under this Project.   |
 # | `blobs`        | The Git {Blob Blobs} imported into this Project.     |
 # | `articles`     | The {Article Articles} imported into this Project.   |
+# | `groups`       | The {Group Groups} imported into this Project.       |
 #
 # Properties
 # ==========
@@ -82,6 +83,7 @@ class Project < ActiveRecord::Base
   has_many :blobs, inverse_of: :project, dependent: :delete_all
   has_many :translations, through: :keys
   has_many :articles, inverse_of: :project
+  has_many :groups, inverse_of: :project, dependent: :destroy
   has_many :sections, through: :articles
 
   serialize :skip_imports,             Array

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,12 @@ en:
           project_not_found: Invalid project
           invalid_api_token: Invalid project API TOKEN
           article_not_found: Article doesn't exist
+        groups:
+          project_not_found: Invalid project
+          invalid_api_token: Invalid project API TOKEN
+          group_not_found: Group does not exist
+          group_found: Group already exists
+          article_not_found: Article %{article_name} does not exist
     application:
       mass_assignment_security: You tried to modify something you weren’t allowed to!
       monitor_required: You must be a monitor to do that.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
             get :manifest, :issues
           end
         end
+        resources :groups, param: :name, only: [:index, :create, :update, :destroy, :show]
       end
     end
   end

--- a/db/migrate/20180814210040_add_group_table.rb
+++ b/db/migrate/20180814210040_add_group_table.rb
@@ -1,0 +1,33 @@
+class AddGroupTable < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE TABLE groups (
+        id SERIAL PRIMARY KEY,
+        project_id integer NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        name text NOT NULL,
+        description text,
+        ready boolean DEFAULT false NOT NULL,
+        loading boolean DEFAULT false NOT NULL,
+        hidden boolean DEFAULT false,
+        due_date date,
+        priority integer,
+        creator_id integer,
+        updater_id integer,
+        email character varying(255),
+        created_via_api boolean DEFAULT true NOT NULL,
+        loaded_at timestamp without time zone,
+        translated_at timestamp without time zone,
+        approved_at timestamp without time zone,
+        created_at timestamp without time zone NOT NULL,
+        updated_at timestamp without time zone NOT NULL
+      )
+    SQL
+
+    add_index(:groups, [:project_id])
+    add_index(:groups, [:name])
+  end
+
+  def down
+    drop_table :groups
+  end
+end

--- a/db/migrate/20180814210112_add_article_group_table.rb
+++ b/db/migrate/20180814210112_add_article_group_table.rb
@@ -1,0 +1,21 @@
+class AddArticleGroupTable < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE TABLE article_groups (
+        id SERIAL PRIMARY KEY,
+        group_id integer NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+        article_id integer NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+        index_in_group integer NOT NULL,
+        created_at timestamp without time zone NOT NULL,
+        updated_at timestamp without time zone NOT NULL
+      )
+    SQL
+
+    add_index(:article_groups, [:group_id])
+    add_index(:article_groups, [:article_id])
+  end
+
+  def down
+    drop_table :article_groups
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.9
--- Dumped by pg_dump version 9.6.9
+-- Dumped from database version 9.6.10
+-- Dumped by pg_dump version 9.6.10
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -32,6 +32,39 @@ COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 SET default_tablespace = '';
 
 SET default_with_oids = false;
+
+--
+-- Name: article_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.article_groups (
+    id integer NOT NULL,
+    group_id integer NOT NULL,
+    article_id integer NOT NULL,
+    index_in_group integer NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: article_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.article_groups_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: article_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.article_groups_id_seq OWNED BY public.article_groups.id;
+
 
 --
 -- Name: articles; Type: TABLE; Schema: public; Owner: -
@@ -328,7 +361,7 @@ ALTER SEQUENCE public.daily_metrics_id_seq OWNED BY public.daily_metrics.id;
 -- Name: edit_reasons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE edit_reasons (
+CREATE TABLE public.edit_reasons (
     id integer NOT NULL,
     reason_id integer,
     translation_change_id integer
@@ -339,8 +372,7 @@ CREATE TABLE edit_reasons (
 -- Name: edit_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE edit_reasons_id_seq
-    AS integer
+CREATE SEQUENCE public.edit_reasons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -352,7 +384,54 @@ CREATE SEQUENCE edit_reasons_id_seq
 -- Name: edit_reasons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE edit_reasons_id_seq OWNED BY edit_reasons.id;
+ALTER SEQUENCE public.edit_reasons_id_seq OWNED BY public.edit_reasons.id;
+
+
+--
+-- Name: groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.groups (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    name text NOT NULL,
+    description text,
+    ready boolean DEFAULT false NOT NULL,
+    loading boolean DEFAULT false NOT NULL,
+    hidden boolean DEFAULT false,
+    due_date date,
+    priority integer,
+    creator_id integer,
+    updater_id integer,
+    email character varying(255),
+    created_via_api boolean DEFAULT true NOT NULL,
+    loaded_at timestamp without time zone,
+    translated_at timestamp without time zone,
+    approved_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.groups_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.groups_id_seq OWNED BY public.groups.id;
+
+
 --
 -- Name: issues; Type: TABLE; Schema: public; Owner: -
 --
@@ -567,7 +646,7 @@ ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 -- Name: reasons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE reasons (
+CREATE TABLE public.reasons (
     id integer NOT NULL,
     name character varying NOT NULL,
     category character varying NOT NULL,
@@ -581,8 +660,7 @@ CREATE TABLE reasons (
 -- Name: reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE reasons_id_seq
-    AS integer
+CREATE SEQUENCE public.reasons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -594,7 +672,7 @@ CREATE SEQUENCE reasons_id_seq
 -- Name: reasons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE reasons_id_seq OWNED BY reasons.id;
+ALTER SEQUENCE public.reasons_id_seq OWNED BY public.reasons.id;
 
 
 --
@@ -885,6 +963,13 @@ ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
+-- Name: article_groups id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.article_groups ALTER COLUMN id SET DEFAULT nextval('public.article_groups_id_seq'::regclass);
+
+
+--
 -- Name: articles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -934,6 +1019,20 @@ ALTER TABLE ONLY public.daily_metrics ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: edit_reasons id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_reasons ALTER COLUMN id SET DEFAULT nextval('public.edit_reasons_id_seq'::regclass);
+
+
+--
+-- Name: groups id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.groups ALTER COLUMN id SET DEFAULT nextval('public.groups_id_seq'::regclass);
+
+
+--
 -- Name: issues id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -966,6 +1065,13 @@ ALTER TABLE ONLY public.locale_glossary_entries ALTER COLUMN id SET DEFAULT next
 --
 
 ALTER TABLE ONLY public.projects ALTER COLUMN id SET DEFAULT nextval('public.projects_id_seq'::regclass);
+
+
+--
+-- Name: reasons id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reasons ALTER COLUMN id SET DEFAULT nextval('public.reasons_id_seq'::regclass);
 
 
 --
@@ -1015,6 +1121,14 @@ ALTER TABLE ONLY public.translations ALTER COLUMN id SET DEFAULT nextval('public
 --
 
 ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Name: article_groups article_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.article_groups
+    ADD CONSTRAINT article_groups_pkey PRIMARY KEY (id);
 
 
 --
@@ -1074,6 +1188,22 @@ ALTER TABLE ONLY public.daily_metrics
 
 
 --
+-- Name: edit_reasons edit_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_reasons
+    ADD CONSTRAINT edit_reasons_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: groups groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.groups
+    ADD CONSTRAINT groups_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: issues issues_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1111,6 +1241,14 @@ ALTER TABLE ONLY public.locale_glossary_entries
 
 ALTER TABLE ONLY public.projects
     ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reasons reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reasons
+    ADD CONSTRAINT reasons_pkey PRIMARY KEY (id);
 
 
 --
@@ -1219,6 +1357,20 @@ CREATE UNIQUE INDEX daily_metrics_date ON public.daily_metrics USING btree (date
 
 
 --
+-- Name: index_article_groups_on_article_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_article_groups_on_article_id ON public.article_groups USING btree (article_id);
+
+
+--
+-- Name: index_article_groups_on_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_article_groups_on_group_id ON public.article_groups USING btree (group_id);
+
+
+--
 -- Name: index_articles_on_name_sha; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1293,6 +1445,34 @@ CREATE INDEX index_commits_on_fingerprint ON public.commits USING btree (fingerp
 --
 
 CREATE UNIQUE INDEX index_commits_on_project_id_and_revision ON public.commits USING btree (project_id, revision);
+
+
+--
+-- Name: index_edit_reasons_on_reason_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_edit_reasons_on_reason_id ON public.edit_reasons USING btree (reason_id);
+
+
+--
+-- Name: index_edit_reasons_on_translation_change_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_edit_reasons_on_translation_change_id ON public.edit_reasons USING btree (translation_change_id);
+
+
+--
+-- Name: index_groups_on_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_groups_on_name ON public.groups USING btree (name);
+
+
+--
+-- Name: index_groups_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_groups_on_project_id ON public.groups USING btree (project_id);
 
 
 --
@@ -1506,6 +1686,22 @@ CREATE UNIQUE INDEX users_unlock_token ON public.users USING btree (unlock_token
 
 
 --
+-- Name: article_groups article_groups_article_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.article_groups
+    ADD CONSTRAINT article_groups_article_id_fkey FOREIGN KEY (article_id) REFERENCES public.articles(id) ON DELETE CASCADE;
+
+
+--
+-- Name: article_groups article_groups_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.article_groups
+    ADD CONSTRAINT article_groups_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON DELETE CASCADE;
+
+
+--
 -- Name: articles articles_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1602,11 +1798,35 @@ ALTER TABLE ONLY public.commits
 
 
 --
+-- Name: edit_reasons fk_rails_bac020938b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_reasons
+    ADD CONSTRAINT fk_rails_bac020938b FOREIGN KEY (reason_id) REFERENCES public.reasons(id);
+
+
+--
 -- Name: translation_changes fk_rails_c5bea0b054; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.translation_changes
     ADD CONSTRAINT fk_rails_c5bea0b054 FOREIGN KEY (article_id) REFERENCES public.articles(id);
+
+
+--
+-- Name: edit_reasons fk_rails_d4c92da42d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_reasons
+    ADD CONSTRAINT fk_rails_d4c92da42d FOREIGN KEY (translation_change_id) REFERENCES public.translation_changes(id);
+
+
+--
+-- Name: groups groups_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.groups
+    ADD CONSTRAINT groups_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
 
 
 --
@@ -1921,6 +2141,15 @@ INSERT INTO schema_migrations (version) VALUES ('20180506023840');
 
 INSERT INTO schema_migrations (version) VALUES ('20180525005743');
 
+INSERT INTO schema_migrations (version) VALUES ('20180604202337');
+
+INSERT INTO schema_migrations (version) VALUES ('20180604202547');
+
 INSERT INTO schema_migrations (version) VALUES ('20180608004859');
 
 INSERT INTO schema_migrations (version) VALUES ('20180722180453');
+
+INSERT INTO schema_migrations (version) VALUES ('20180814210040');
+
+INSERT INTO schema_migrations (version) VALUES ('20180814210112');
+

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -1,0 +1,255 @@
+# encoding: utf-8
+
+# Copyright 2014 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the 'License');
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an 'AS IS' BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+require 'rails_helper'
+
+RSpec.describe API::V1::GroupsController do
+  let(:project) { FactoryBot.create(:project, repository_url: nil, base_rfc5646_locale: 'en', targeted_rfc5646_locales: { 'fr' => true, 'es' => false } ) }
+  let(:monitor_user) { FactoryBot.create(:user, :confirmed, role: 'monitor') }
+  let(:reviewer_user) { FactoryBot.create(:user, :confirmed, role: 'reviewer') }
+  let!(:article1) { FactoryBot.create(:article, project: project) }
+  let!(:article2) { FactoryBot.create(:article, project: project) }
+  let!(:article3) { FactoryBot.create(:article, project: project) }
+  let!(:group1) { FactoryBot.create(:group, name: 'group-1', project: project) }
+  let!(:group2) { FactoryBot.create(:group, name: 'group-2', project: project) }
+
+  before do
+    article2.update(ready: true)
+  end
+
+  def sign_in_monitor_user
+    request.env['devise.mapping'] = Devise.mappings[:user]
+    sign_in monitor_user
+  end
+
+  def sign_in_reviewer_user
+    request.env['devise.mapping'] = Devise.mappings[:user]
+    sign_in reviewer_user
+  end
+
+  RSpec.shared_examples_for 'api-or-session-authenticateable-and-filters' do
+    context '[auth with api_token]' do
+      it 'errors with API error message if wrong api_token is provided' do
+        send request_type, action, params.merge(project_id: project.id, format: :json, api_token: 'fake')
+        expect(response.status).to eql(401)
+        expect(JSON.parse(response.body)).to eql({'error'=>{'errors'=>[{'message'=>'Invalid project API TOKEN'}]}})
+      end
+
+      it 'authenticates with api_token' do
+        send request_type, action, params.merge(project_id: project.id, format: :json, api_token: project.api_token)
+        expect(assigns(:project)).to eq(project) # if @project is set, it means authentication was successful
+      end
+    end
+
+    context '[auth without api_token]' do
+      it 'errors with non-API error message if there is no signed in user' do
+        send request_type, action, params.merge(project_id: project.id, format: :json)
+        expect(response.status).to eql(401)
+        expect(JSON.parse(response.body)).to eql({'error'=>'You need to sign in or sign up before continuing.'})
+      end
+
+      it 'authenticates with session if there is a signed in user' do
+        sign_in_monitor_user
+        send request_type, action, params.merge(project_id: project.id, format: :json)
+        expect(assigns(:project)).to eq(project) # if @project is set, it means authentication was successful
+      end
+    end
+
+    it 'errors with project-not-found message if project_id is invalid (only makes sense with session-auth; because for API-auth, it would error with invalid-token-api message)' do
+      sign_in_monitor_user
+      send request_type, action, params.merge(project_id: -1, format: :json)
+      expect(assigns(:project)).to be_nil
+      expect(JSON.parse(response.body)).to eql({'error'=>{'errors'=>[{'message'=>'Invalid project'}]}})
+    end
+  end
+
+  describe '#index' do
+    it_behaves_like 'api-or-session-authenticateable-and-filters', runs_find_group_filter: false do
+      let(:request_type) { :get }
+      let(:action) { :index }
+      let(:params) { {} }
+    end
+
+    it 'returns all Groups in the project' do
+      get :index, project_id: project.id, api_token: project.api_token, format: :json
+
+      expect(response.status).to eql(200)
+      expect(JSON.parse(response.body)).to match_array(['group-1', 'group-2'])
+    end
+  end
+
+  describe '#create' do
+    it_behaves_like 'api-or-session-authenticateable-and-filters', runs_find_group_filter: false do
+      let(:request_type) { :post }
+      let(:action) { :create }
+      let(:params) { { name: 'dummy-group', article_names: [] } }
+    end
+
+    it 'creates a Group' do
+      article_names = [article2.name, article1.name, article3.name]
+      post :create, project_id: project.id, api_token: project.api_token, name: 'test-group', article_names: article_names, format: :json
+
+      expect(response.status).to eql(200)
+      expect(JSON.parse(response.body)).to eq([
+                                                { 'name' => article2.name, 'ready' => true },
+                                                { 'name' => article1.name, 'ready' => false },
+                                                { 'name' => article3.name, 'ready' => false }
+                                              ])
+
+      groups = project.groups.where(name: 'test-group')
+      expect(groups.count).to eq(1)
+      expect(groups.first.articles).to match_array([article2, article1, article3])
+    end
+
+    it 'fails when project has same group name' do
+      post :create, project_id: project.id, api_token: project.api_token,  name: group1.name, article_names: [article1.name], format: :json
+
+      expect(response.status).to eql(400)
+      expect(JSON.parse(response.body)).to match_array({'error'=>{'errors'=>[{'message'=>'Group already exists'}]}})
+    end
+
+    it 'succeeds when other project has same group name' do
+      other_project = FactoryBot.create(:project, repository_url: nil, base_rfc5646_locale: 'en', targeted_rfc5646_locales: { 'fr' => true, 'es' => false } )
+      FactoryBot.create(:group, name: 'test-group', project: other_project)
+
+      article_names = [article2.name, article1.name, article3.name]
+      post :create, project_id: project.id, api_token: project.api_token, name: 'test-group', article_names: article_names, format: :json
+
+      expect(response.status).to eql(200)
+    end
+
+    it 'fails when articles do not exist' do
+      article_names = [article1.name, 'dummy-article-1', 'dummy-article-2']
+      post :create, project_id: project.id, api_token: project.api_token,  name:'test-group', article_names: article_names, format: :json
+
+      expect(response.status).to eql(400)
+      expect(JSON.parse(response.body)).to match_array({'error'=>{'errors'=>['Article dummy-article-1 does not exist', 'Article dummy-article-2 does not exist']}})
+    end
+
+    it 'fails when other project has the article' do
+      other_project = FactoryBot.create(:project, repository_url: nil, base_rfc5646_locale: 'en', targeted_rfc5646_locales: { 'fr' => true, 'es' => false } )
+      other_article = FactoryBot.create(:article, name: 'other-article', project: other_project)
+
+      article_names = [other_article.name]
+      post :create, project_id: project.id, api_token: project.api_token,  name:'test-group', article_names: article_names, format: :json
+
+      expect(response.status).to eql(400)
+      expect(JSON.parse(response.body)).to match_array({'error'=>{'errors'=>['Article other-article does not exist']}})
+    end
+  end
+
+  describe '#show' do
+    before do
+      FactoryBot.create(:article_group, article: article1, group: group1, index_in_group: 1)
+      FactoryBot.create(:article_group, article: article3, group: group1, index_in_group: 0)
+    end
+
+    it_behaves_like 'api-or-session-authenticateable-and-filters' do
+      let(:request_type) { :get }
+      let(:action) { :show }
+      let(:params) { { name: group1.name } }
+    end
+
+    it 'returns articles in the group' do
+      get :show, project_id: project.id, api_token: project.api_token, name: group1.name, format: :json
+
+      expect(response.status).to eql(200)
+      expect(JSON.parse(response.body)).to eq([
+                                                  { 'name' => article3.name, 'ready' => false },
+                                                  { 'name' => article1.name, 'ready' => false }
+                                              ])
+    end
+
+    it 'fails when group does not exist' do
+      get :show, project_id: project.id, api_token: project.api_token, name: 'dummy-artcile-group', format: :json
+
+      expect(response.status).to eql(404)
+      expect(JSON.parse(response.body)).to match_array({'error'=>{'errors'=>[{'message'=>'Group does not exist'}]}})
+    end
+  end
+
+  describe '#update' do
+    before do
+      FactoryBot.create(:article_group, article: article1, group: group1, index_in_group: 1)
+      FactoryBot.create(:article_group, article: article3, group: group1, index_in_group: 0)
+    end
+
+    it_behaves_like 'api-or-session-authenticateable-and-filters' do
+      let(:request_type) { :patch }
+      let(:action) { :update }
+      let(:params) { { name: group1.name, article_names: [] } }
+    end
+
+    it 'updates articles in the group' do
+      expect(project.groups.find_by_name(group1.name).articles).to match_array([article1, article3])
+
+      article_names = [article2.name, article3.name]
+      patch :update, project_id: project.id, api_token: project.api_token, name: group1.name, article_names: article_names, format: :json
+
+      expect(response.status).to eql(200)
+      expect(JSON.parse(response.body)).to eq([
+                                                  { 'name' => article2.name, 'ready' => true },
+                                                  { 'name' => article3.name, 'ready' => false }
+                                              ])
+
+      expect(project.groups.find_by_name(group1.name).articles).to match_array([article2, article3])
+    end
+
+    it 'fails when group does not exist' do
+      patch :update, project_id: project.id, api_token: project.api_token, name: 'dummy-article-group', article_names: [], format: :json
+
+      expect(response.status).to eql(404)
+      expect(JSON.parse(response.body)).to match_array({'error'=>{'errors'=>[{'message'=>'Group does not exist'}]}})
+    end
+
+    it 'fails when articles do not exist' do
+      article_names = [article1.name, 'dummy-article-1', 'dummy-article-2']
+      patch :update, project_id: project.id, api_token: project.api_token, name: group1.name, article_names: article_names, format: :json
+
+      expect(response.status).to eql(400)
+      expect(JSON.parse(response.body)).to match_array({'error'=>{'errors'=>['Article dummy-article-1 does not exist', 'Article dummy-article-2 does not exist']}})
+    end
+  end
+
+  describe '#destroy' do
+    before do
+      FactoryBot.create(:article_group, article: article1, group: group1, index_in_group: 1)
+      FactoryBot.create(:article_group, article: article3, group: group1, index_in_group: 0)
+    end
+
+    it_behaves_like 'api-or-session-authenticateable-and-filters' do
+      let(:request_type) { :delete }
+      let(:action) { :destroy }
+      let(:params) { { name: group1.name } }
+    end
+
+    it 'deletes articles in the group' do
+      delete :destroy, project_id: project.id, api_token: project.api_token, name: group1.name, format: :json
+
+      expect(response.status).to eql(200)
+      expect(JSON.parse(response.body)).to eq({ "status" => true })
+
+      expect(project.groups.where(name: group1.name).count).to eq(0)
+    end
+
+    it 'fails when group does not exist' do
+      delete :destroy, project_id: project.id, api_token: project.api_token, name: 'dummy-article-group', format: :json
+
+      expect(response.status).to eql(404)
+      expect(JSON.parse(response.body)).to match_array({'error'=>{'errors'=>[{'message'=>'Group does not exist'}]}})
+    end
+  end
+end

--- a/spec/factories/article_groups.rb
+++ b/spec/factories/article_groups.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :article_group do
+    association :article
+    association :group
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,20 @@
+# Copyright 2014 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+FactoryBot.define do
+  factory :group do
+    association :project, repository_url: nil
+    sequence(:name) { |i| "group-#{i}" }
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -533,6 +533,35 @@ RSpec.describe Article do
     end
   end
 
+  describe '#groups' do
+    let(:project) { FactoryBot.create(:project, repository_url: nil, base_rfc5646_locale: 'en', targeted_rfc5646_locales: { 'fr' => true, 'es' => false } ) }
+    let(:article1) { FactoryBot.create(:article, project: project) }
+    let(:article2) { FactoryBot.create(:article, project: project) }
+    let(:article3) { FactoryBot.create(:article, project: project) }
+    let(:group1) { FactoryBot.create(:group, project: project) }
+    let(:group2) { FactoryBot.create(:group, project: project) }
+
+    let!(:article_group11) { FactoryBot.create(:article_group, group: group1, article: article1, index_in_group: 1) }
+    let!(:article_group12) { FactoryBot.create(:article_group, group: group1, article: article2, index_in_group: 2) }
+    let!(:article_group21) { FactoryBot.create(:article_group, group: group2, article: article2, index_in_group: 1) }
+    let!(:article_group22) { FactoryBot.create(:article_group, group: group2, article: article3, index_in_group: 2) }
+
+    it 'includes proper groups' do
+      expect(Article.find(article1.id).groups).to match_array([group1])
+      expect(Article.find(article2.id).groups).to match_array([group1, group2])
+      expect(Article.find(article3.id).groups).to match_array([group2])
+
+      expect(group1.articles).to match_array([article1, article2])
+      expect(group2.articles).to match_array([article2, article3])
+    end
+
+    it 'destroys its groups after articles are destroyed' do
+      article2.destroy
+
+      expect(group1.articles).to match_array([article1])
+    end
+  end
+
   # ======== END IMPORT RELATED CODE ===================================================================================
 
   # ======== START ERRORS RELATED CODE =================================================================================

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,122 @@
+# Copyright 2015 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+require 'rails_helper'
+require 'models/concerns/common_locale_logic_spec'
+
+RSpec.describe Group do
+  # ======== START BASIC CRUD RELATED CODE =============================================================================
+  describe "[validations]" do
+    it "doesn't allow creating 2 Groups in the same project with the same name" do
+      group = FactoryBot.create(:group, name: "hello")
+      group_new = FactoryBot.build(:group, name: "hello", project: group.project).tap(&:save)
+      expect(group_new).to_not be_persisted
+      expect(group_new.errors.messages).to eql({:name =>["already taken"]})
+    end
+
+    it "allows creating 2 Groups with the same name under different projects" do
+      FactoryBot.create(:group, name: "hello")
+      group_new = FactoryBot.build(:group, name: "hello", project: FactoryBot.create(:project)).tap(&:save)
+      expect(group_new).to be_persisted
+      expect(group_new.errors).to_not be_any
+    end
+
+    it "doesn't allow creating without a name" do
+      group = FactoryBot.build(:group, name: nil).tap(&:save)
+      expect(group).to_not be_persisted
+      expect(group.errors.messages).to eql({name: ["can’t be blank"]})
+    end
+
+    it "doesn't allow name to be 'new'" do
+      group = FactoryBot.build(:group, name: 'new').tap(&:save)
+      expect(group.errors.full_messages).to include("Name reserved")
+    end
+  end
+
+  describe '[scopes]' do
+    context '#hidden' do
+      let!(:group1) { FactoryBot.create(:group, hidden: true) }
+      let!(:group2) { FactoryBot.create(:group, hidden: false) }
+
+      it 'returns only the hidden groups' do
+        expect(Group.hidden).to match_array([group1])
+      end
+
+      it '#showing returns only the showing groups' do
+        expect(Group.showing).to match_array([group2])
+      end
+    end
+
+    context '#ready' do
+      let!(:group1) { FactoryBot.create(:group, ready: true) }
+      let!(:group2) { FactoryBot.create(:group, ready: false) }
+
+      it 'returns only the ready groups' do
+        expect(Group.ready).to match_array([group1])
+      end
+
+      it '#not_ready returns only the ready groups' do
+        expect(Group.not_ready).to match_array([group2])
+      end
+    end
+  end
+
+  context '#loading' do
+    let!(:group1) { FactoryBot.create(:group, loading: true) }
+    let!(:group2) { FactoryBot.create(:group, loading: false) }
+
+    it 'returns only the loading groups' do
+      expect(Group.loading).to match_array([group1])
+    end
+  end
+  # ======== END BASIC CRUD RELATED CODE ===============================================================================
+
+  describe '#project' do
+    let(:project) { FactoryBot.create(:project, repository_url: nil, base_rfc5646_locale: 'en', targeted_rfc5646_locales: { 'fr' => true, 'es' => false } ) }
+    let(:group) { FactoryBot.create(:group, project: project) }
+
+    it 'has proper project' do
+      expect(group.project).to eq(project)
+    end
+  end
+
+  describe '#articles' do
+    let(:project) { FactoryBot.create(:project, repository_url: nil, base_rfc5646_locale: 'en', targeted_rfc5646_locales: { 'fr' => true, 'es' => false } ) }
+    let(:group) { FactoryBot.create(:group, project: project) }
+
+    let(:article1) { FactoryBot.create(:article, targeted_rfc5646_locales: {'fr' => true}) }
+    let(:article2) { FactoryBot.create(:article, targeted_rfc5646_locales: {'fr' => true}) }
+
+    let!(:article_group1) { FactoryBot.create(:article_group, article: article1, group: group, index_in_group: 2) }
+    let!(:article_group2) { FactoryBot.create(:article_group, article: article2, group: group, index_in_group: 1) }
+
+    it 'has proper articles' do
+      expect(Group.find(group.id).articles).to match_array([article1, article2])
+    end
+
+    it 'destroys its article_groups after group is destroyed' do
+      group.destroy
+
+      expect(ArticleGroup.where(group_id: group.id)).to eq([])
+    end
+  end
+
+  describe '#to_param' do
+    let(:group) { FactoryBot.create(:group, loading: true) }
+
+    it 'returns name of group' do
+      expect(group.to_param).to eq(group.name)
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -761,4 +761,20 @@ RSpec.describe Project do
       expect(project.not_git?).to be_truthy
     end
   end
+
+  describe '#groups' do
+    let(:project) { FactoryBot.create(:project, repository_url: nil, base_rfc5646_locale: 'en', targeted_rfc5646_locales: { 'fr' => true, 'es' => false } ) }
+    let!(:group1) { FactoryBot.create(:group, project: project) }
+    let!(:group2) { FactoryBot.create(:group, project: project) }
+
+    it 'includes proper groups' do
+      expect(project.groups).to match_array([group1, group2])
+    end
+
+    it 'destroys its group after project are destroyed' do
+      project.destroy
+
+      expect(Group.where(id: [group1.id, group2.id])).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
Group is a new entity. Each group contains a list of articles in specified order. The easiest way to think about group as a web page. Each component in the page is an article.Each page contains many components, aka many articles.

When presenting translations in an article group to translators and reviewers, the UI compiles the translations in the same order as the article orders specified in group. This provides translators the
page context for each translation.