### PR TITLE
Fix translation reason flag.

### DIFF
--- a/app/views/locale/projects/show.js.coffee.erb
+++ b/app/views/locale/projects/show.js.coffee.erb
@@ -54,5 +54,5 @@ $(document).ready ->
     JSON.parse("<%= escape_javascript @glossary_entries.to_json %>"),
     JSON.parse('<%= escape_javascript @presenter.decorate_translations(@translations) %>'),
     "<%= @presenter.role %>",
-    "<%= Shuttle::Configuration.workbench.enable_reasons %>"
+    JSON.parse("<%= Shuttle::Configuration.workbench.enable_reasons %>")
   )


### PR DESCRIPTION
The reason should be passed as boolean instead of a string ('true'/'false').