### PR TITLE
Switched Translator Report to use last_completed_at for the article approval date

### DIFF
--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -95,7 +95,7 @@ module Reports
                  sha,
                  articles.name as article_name,
                  COALESCE(MIN(commits.created_at), MIN(articles.created_at)) as job_start,
-                 COALESCE(MAX(commits.approved_at), MAX(articles.first_completed_at)) as approved_at')
+                 COALESCE(MAX(commits.approved_at), MAX(articles.last_completed_at)) as approved_at')
       add_shared(query, languages, exclude_internal)
     end
 
@@ -110,14 +110,14 @@ module Reports
                 MAX(commits.approved_at) as approved_at')
       commit_query = add_shared(commit_query, languages, exclude_internal)
 
-      article_query = TranslationChange.where('articles.first_completed_at': start_date.beginning_of_day..end_date.end_of_day)
+      article_query = TranslationChange.where('articles.last_completed_at': start_date.beginning_of_day..end_date.end_of_day)
         .joins('JOIN articles ON articles.id = article_id')
-        .group('DATE(articles.first_completed_at), articles.name')
-        .select('DATE(articles.first_completed_at) as "date",
+        .group('DATE(articles.last_completed_at), articles.name')
+        .select('DATE(articles.last_completed_at) as "date",
                  NULL,
                  articles.name as article_name,
                  MIN(articles.created_at) as job_start,
-                 MAX(articles.first_completed_at) as approved_at')
+                 MAX(articles.last_completed_at) as approved_at')
       article_query = add_shared(article_query, languages, exclude_internal)
 
       TranslationChange.from_cte('foo', commit_query.union(article_query))

--- a/spec/lib/reports/translator_report_spec.rb
+++ b/spec/lib/reports/translator_report_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Reports::TranslatorReport do
         @commit = FactoryBot.create(:commit, project: @project, approved_at: @end_date)
         @reviewer = FactoryBot.create(:user, :reviewer, approved_rfc5646_locales: %w(it fr), first_name: 'Mark', email: 'mark@test.host')
         @translator = FactoryBot.create(:user, :translator, approved_rfc5646_locales: %w(it fr), first_name: 'Rebecca')
-        @article = FactoryBot.create(:article, project: @article_project, created_at: @start_date, first_completed_at: @end_date)
+        @article = FactoryBot.create(:article, project: @article_project, created_at: @start_date, last_completed_at: @end_date)
 
         key1 = FactoryBot.create(:key, project: @project)
         key2 = FactoryBot.create(:key, project: @project)


### PR DESCRIPTION
This is a quick fix for the Translator Report. Previously it was using the `first_completed_at` date for the approval date, now it's using the correct one, the `last_completed_at` date.