### PR TITLE
Fix project update with missing existing locale key filtering.

### DIFF
--- a/app/assets/javascripts/application/multi_field.js.coffee
+++ b/app/assets/javascripts/application/multi_field.js.coffee
@@ -168,7 +168,7 @@ class root.HashField
     div = $('<div/>').addClass('hashfield-element').insertBefore(@element.find('>.multifield-last-element'))
 
     @options.renderer div, key, value, this
-    key_field = div.find('[rel=key]')
+    key_field = div.find('.tt-input[rel=key]')
     value_field = div.find('[rel=value]')
     refreshName = (locale) =>
       new_key = key_field.val() || locale


### PR DESCRIPTION
When update a project with existing locale key filtering, client does not
pass the existing locale key filtering back to server properly and causes
all existing locale key filtering disappear.

The locale field is using twitter typehead, which has two fields called
`[rel=key]`. While reading the input locale value, it reads from wrong
field and gets an empty string. It triggers callback to unset the `name`
attribute in the key filtering input field.

Here is the example of a locale field:
```
<span class="twitter-typeahead" style="position: relative; display: inline-block;">
    <input type="text" rel="key" class="locale-field tt-hint" readonly="" autocomplete="off" spellcheck="false" tabindex="-1" dir="ltr" style="position: absolute; top: 0px; left: 0px; border-color: transparent; box-shadow: none; opacity: 1; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(251, 252, 252);">
    <input type="text" rel="key" placeholder="Locale" name="es" class="locale-field tt-input" autocomplete="off" spellcheck="false" dir="auto" style="position: relative; vertical-align: top; background-color: transparent;">
    <img src="/assets/country-flags/es-7b6f223153c8eda1b541326f9cd66aeb53a28801c58c4de751fd2f9f6f1d96ff.png" class="locale-flag" style="top: 4px;">
    ......
</span>
```