### PR TITLE
tlex no more writing the BOM for iOS strings files since we're now us…

### DIFF
--- a/lib/exporter/strings.rb
+++ b/lib/exporter/strings.rb
@@ -36,10 +36,6 @@ module Exporter
       raise NoLocaleProvidedError, ".strings files can only be for a single locale" unless locales.size == 1
       locale = locales.first
 
-      # write the BOM
-      io.putc 0xFF
-      io.putc 0xFE
-
       translations = Translation.in_commit(@commit).where(rfc5646_locale: locale.rfc5646).
           sort_by { |t| t.key.key }
       translations.each { |translation| export_translation io, translation }


### PR DESCRIPTION
…ing UTF8. BOM is optional with UTF8 and can even cause issues with certain file readers.