### PR TITLE
Translator Report: Assets

### DIFF
--- a/app/assets/javascripts/application/translation_workbench.js.coffee
+++ b/app/assets/javascripts/application/translation_workbench.js.coffee
@@ -111,6 +111,7 @@ class TranslationItem
     params = (new URL(document.location)).searchParams
     sha = params.get('commit')
     articleId = params.get('article_id')
+    assetId = params.get('asset_id')
 
     ajaxParams = {}
     ajaxParams['translation[copy]'] = copy
@@ -118,6 +119,7 @@ class TranslationItem
     ajaxParams['commit'] = sha
     ajaxParams['reason_ids'] = reason_ids if reason_ids.length
     ajaxParams['article_id'] = articleId if articleId
+    ajaxParams['asset_id'] = assetId if assetId
 
     $.ajax translation.url + '.json',
       type: 'PUT'

--- a/app/models/translation_change.rb
+++ b/app/models/translation_change.rb
@@ -32,6 +32,7 @@ class TranslationChange < ActiveRecord::Base
   belongs_to :user
   belongs_to :project
   belongs_to :article
+  belongs_to :asset
   has_many :edit_reasons
   has_many :reasons, through: :edit_reasons
 
@@ -50,6 +51,7 @@ class TranslationChange < ActiveRecord::Base
       project_id = Project.joins(:slugs).where('slugs.slug = ?', params[:project_id]).pluck('projects.id').first
       commit = (params[:commit] == 'Save') ? nil : params[:commit]
       article_id = params[:article_id] || translation.article&.id
+      asset_id = params[:asset_id]
 
       tran = TranslationChange.create(
         translation: translation,
@@ -60,7 +62,8 @@ class TranslationChange < ActiveRecord::Base
         tm_match: translation.tm_match,
         sha: commit,
         article_id: article_id,
-        project_id: project_id
+        project_id: project_id,
+        asset_id: asset_id
       )
       tran.reason_ids = params[:reason_ids] if params[:reason_ids]
     end

--- a/app/workers/asset_xlsx_importer.rb
+++ b/app/workers/asset_xlsx_importer.rb
@@ -23,11 +23,11 @@ class AssetXlsxImporter
   end
 
   def get_workbook(file)
-    if file.class == Paperclip::Attachment
+    if File.file?(file.path)
+      RubyXL::Parser.parse(file.path)
+    else
       content = open(file.url).read
       RubyXL::Parser.parse_buffer(content)
-    else
-      RubyXL::Parser.parse(file.path)
     end
   end
 

--- a/db/migrate/20180924195012_add_asset_id_to_translation_changes.rb
+++ b/db/migrate/20180924195012_add_asset_id_to_translation_changes.rb
@@ -1,0 +1,5 @@
+class AddAssetIdToTranslationChanges < ActiveRecord::Migration
+  def change
+    add_reference :translation_changes, :asset, index: true, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -925,7 +925,8 @@ CREATE TABLE public.translation_changes (
     role character varying,
     project_id integer,
     is_edit boolean DEFAULT false,
-    article_id integer
+    article_id integer,
+    asset_id integer
 );
 
 
@@ -2259,3 +2260,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180814210040');
 INSERT INTO schema_migrations (version) VALUES ('20180814210112');
 
 INSERT INTO schema_migrations (version) VALUES ('20180825234430');
+
+INSERT INTO schema_migrations (version) VALUES ('20180924195012');
+

--- a/lib/exporter/asset.rb
+++ b/lib/exporter/asset.rb
@@ -64,6 +64,12 @@ module Exporter
 
 private
     def generate_xlsx(asset, locale)
+      if File.file?(asset.file.path)
+        RubyXL::Parser.parse(asset.file.path)
+      else
+        content = open(asset.file.url).read
+        RubyXL::Parser.parse_buffer(content)
+      end
       workbook = RubyXL::Parser.parse(asset.file.path)
 
       asset.translations.in_locale(locale).each do |translation|

--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -27,7 +27,7 @@ module Reports
       # and that languages is an array
       raise ArgumentError, 'languages must be an array' unless languages.kind_of?(Array)
 
-      empty_cols = Array.new(14, '')
+      empty_cols = Array.new(15, '')
 
       CSV.generate do |csv|
         if report_type == 'completed'
@@ -41,7 +41,7 @@ module Reports
         csv << ['Language(s)', "#{languages.sort.join(", ").upcase}"] + empty_cols
         csv << ['', ''] + empty_cols
         csv << ['Translator Report', report_type.titlecase] + empty_cols
-        csv << ['Date', 'User', 'User Id', 'Role', 'Source Language', 'Language (Locale)', 'Project Name', 'Job Name (SHA)', 'Article Name', 'Job Start', 'Approval Date', 'New Words', '60-69%', '70-79%%', '80-89%', '90-99%', '100%']
+        csv << ['Date', 'User', 'User Id', 'Role', 'Source Language', 'Language (Locale)', 'Project Name', 'Project Type', 'Job Name/Id', 'Job Start', 'Approval Date', 'New Words', '60-69%', '70-79%%', '80-89%', '90-99%', '100%']
 
         translator_query.group_by(&:group_id).each do |group, records|
           tc = records.first
@@ -51,11 +51,12 @@ module Reports
           records.each do |rec|
             counts[rec.classification] = rec.words_count
           end
-          article = (tc.article_name || '')
-          sha = (tc.sha || '')
+          article = tc.article_name
+          sha = tc.sha
+          asset = tc.asset_id
           job_start = (tc.job_start ? tc.job_start.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
           approved_at = (tc.approved_at ? tc.approved_at.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
-          csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.source_rfc5646_locale.upcase, tc.rfc5646_locale.upcase, tc.project_name, sha, article, job_start, approved_at, counts].flatten
+          csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.source_rfc5646_locale.upcase, tc.rfc5646_locale.upcase, tc.project_name, Project.job_types.key(tc.job_type).titlecase, (sha || article || asset), job_start, approved_at, counts].flatten
         end
       end
     end
@@ -69,13 +70,14 @@ module Reports
       query.where('translation_changes.tm_match IS NOT NULL')
            .where('translations.rfc5646_locale': languages)
            .joins(:project, :user, :translation)
-           .group('source_rfc5646_locale, rfc5646_locale, translation_changes.role, projects.name, first_name, users.id, classification')
+           .group('source_rfc5646_locale, rfc5646_locale, translation_changes.role, projects.name, projects.job_type, first_name, users.id, classification')
            .select('users.first_name,
                    users.id as user_id,
                    translation_changes.role,
                    source_rfc5646_locale,
                    rfc5646_locale,
                    projects.name as project_name,
+                   projects.job_type as job_type,
                    -- the following take the tm_match and converts it to a number 0-5
                    CASE WHEN translation_changes.tm_match < 60 THEN 0 ELSE FLOOR((translation_changes.tm_match - 50)/10) END as classification,
                    SUM(words_count) as words_count')
@@ -85,17 +87,19 @@ module Reports
       query = TranslationChange.where('translation_changes.created_at': start_date.beginning_of_day..end_date.end_of_day)
         .joins('LEFT OUTER JOIN articles ON articles.id = article_id')
         .joins('LEFT OUTER JOIN commits ON commits.revision = sha')
+        .joins('LEFT OUTER JOIN assets ON assets.id = asset_id')
         .group('DATE(translation_changes.created_at)')
-        .group('articles.name, sha')
+        .group('articles.name, sha, assets.id')
         .order('group_id', 'rfc5646_locale', 'source_rfc5646_locale', 'projects.name', 'first_name', 'classification')
         .select('RANK() OVER (
-                   ORDER BY DATE(translation_changes.created_at), rfc5646_locale, projects.name, sha, articles.name, first_name
+                   ORDER BY DATE(translation_changes.created_at), rfc5646_locale, projects.name, sha, articles.name, assets.id, first_name
                  ) AS group_id,
                  DATE(translation_changes.created_at) as "date",
                  sha,
                  articles.name as article_name,
-                 COALESCE(MIN(commits.created_at), MIN(articles.created_at)) as job_start,
-                 COALESCE(MAX(commits.approved_at), MAX(articles.last_completed_at)) as approved_at')
+                 assets.id as asset_id,
+                 COALESCE(MIN(commits.created_at), MIN(articles.created_at), MIN(assets.created_at)) as job_start,
+                 COALESCE(MAX(commits.approved_at), MAX(articles.last_completed_at), MAX(assets.approved_at)) as approved_at')
       add_shared(query, languages, exclude_internal)
     end
 
@@ -106,6 +110,7 @@ module Reports
         .select('DATE(commits.approved_at) as "date",
                 sha,
                 NULL as article_name,
+                NULL as asset_id,
                 MIN(commits.created_at) as job_start,
                 MAX(commits.approved_at) as approved_at')
       commit_query = add_shared(commit_query, languages, exclude_internal)
@@ -116,13 +121,25 @@ module Reports
         .select('DATE(articles.last_completed_at) as "date",
                  NULL,
                  articles.name as article_name,
+                 NULL as asset_id,
                  MIN(articles.created_at) as job_start,
                  MAX(articles.last_completed_at) as approved_at')
       article_query = add_shared(article_query, languages, exclude_internal)
 
-      TranslationChange.from_cte('foo', commit_query.union(article_query))
+      asset_query = TranslationChange.where('assets.approved_at': start_date.beginning_of_day..end_date.end_of_day)
+        .joins('JOIN assets ON assets.id = asset_id')
+        .group('DATE(assets.approved_at), assets.id')
+        .select('DATE(assets.approved_at) as "date",
+                NULL as sha,
+                NULL as article_name,
+                CAST(assets.id as varchar) as asset_id,
+                MIN(assets.created_at) as job_start,
+                MAX(assets.approved_at) as approved_at')
+      asset_query = add_shared(asset_query, languages, exclude_internal)
+
+      TranslationChange.from_cte('foo', commit_query.union(article_query).union(asset_query))
                        .select('RANK() OVER (
-                          ORDER BY date, rfc5646_locale, project_name, sha, article_name, first_name
+                          ORDER BY date, rfc5646_locale, project_name, sha, article_name, asset_id, first_name
                         ) AS group_id, *')
                        .order('group_id', 'rfc5646_locale', 'source_rfc5646_locale', 'project_name', 'first_name', 'classification')
     end

--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -51,12 +51,14 @@ module Reports
           records.each do |rec|
             counts[rec.classification] = rec.words_count
           end
-          article = tc.article_name
-          sha = tc.sha
-          asset = tc.asset_id
+          article = (tc.article_name.blank?) ? nil : tc.article_name
+          sha = (tc.sha.blank?) ? nil : tc.sha
+          asset = (tc.asset_id.blank?) ? nil : tc.asset_id
           job_start = (tc.job_start ? tc.job_start.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
           approved_at = (tc.approved_at ? tc.approved_at.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
-          csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.source_rfc5646_locale.upcase, tc.rfc5646_locale.upcase, tc.project_name, Project.job_types.key(tc.job_type).titlecase, (sha || article || asset), job_start, approved_at, counts].flatten
+
+          p (sha || article || asset).to_s
+          csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.source_rfc5646_locale.upcase, tc.rfc5646_locale.upcase, tc.project_name, Project.job_types.key(tc.job_type).titlecase, (sha || article || asset).to_s, job_start, approved_at, counts].flatten
         end
       end
     end

--- a/spec/lib/reports/translator_report_spec.rb
+++ b/spec/lib/reports/translator_report_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Reports::TranslatorReport do
         @languages = ['it', 'fr']
 
         @project = FactoryBot.create(:project, name: 'Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
-        @article_project = FactoryBot.create(:project, name: 'Article Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
+        @article_project = FactoryBot.create(:project, name: 'Article Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true }, job_type: 2)
         @commit = FactoryBot.create(:commit, project: @project, approved_at: @end_date)
         @reviewer = FactoryBot.create(:user, :reviewer, approved_rfc5646_locales: %w(it fr), first_name: 'Mark', email: 'mark@test.host')
         @translator = FactoryBot.create(:user, :translator, approved_rfc5646_locales: %w(it fr), first_name: 'Rebecca')
@@ -91,19 +91,19 @@ RSpec.describe Reports::TranslatorReport do
 
         it 'has the expected start and end date' do
           expected_results = [
-            ["Start Date", @start_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", "", ""],
-            ["End Date", @end_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
+            ["Start Date", @start_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""],
+            ["End Date", @end_date.strftime("%Y-%m-%d"), "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
           ]
           expect(result[0..1]).to eql expected_results
         end
 
         it 'has the expected languages' do
-          expected_results = ["Language(s)", "FR, IT", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
+          expected_results = ["Language(s)", "FR, IT", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
           expect(result[2]).to eql expected_results
         end
 
         it 'has the expected column headers' do
-          expected_results = ["Date", "User", "User Id", "Role", "Source Language", "Language (Locale)", "Project Name", "Job Name (SHA)", "Article Name", "Job Start", "Approval Date", "New Words", "60-69%", "70-79%%", "80-89%", "90-99%", "100%"]
+          expected_results = ["Date", "User", "User Id", "Role", "Source Language", "Language (Locale)", "Project Name", "Project Type", "Job Name/Id", "Job Start", "Approval Date", "New Words", "60-69%", "70-79%%", "80-89%", "90-99%", "100%"]
           expect(result[5]).to eql expected_results
         end
       end
@@ -118,42 +118,42 @@ RSpec.describe Reports::TranslatorReport do
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages)) }
 
         it 'has the expected row 6' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",    'reviewer',  'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",    'reviewer',  'EN-US', 'FR', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'FR', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",     'reviewer', 'EN-US', 'IT', project, sha, '', commit_start, approved_at,'0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",     'reviewer', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at,'0', '0', '0', '3', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '3', '0', '0']
           expect(result[9]).to eql expected_results
         end
 
         it 'has the expected row 10' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer', 'EN-US', 'IT',  @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer', 'EN-US', 'IT',  @article_project.name, @article_project.job_type.titlecase, article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[10]).to eql expected_results
         end
 
         it 'has the expected row 11' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",     'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",     'translator', 'EN-US', 'IT',   @article_project.name, @article_project.job_type.titlecase, article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[11]).to eql expected_results
         end
 
         it 'has the expected row 12' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '0', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '0', '3', '0']
           expect(result[12]).to eql expected_results
         end
 
         it 'has the expected row 13' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '0', '3', '0']
           expect(result[13]).to eql expected_results
         end
 
@@ -172,22 +172,22 @@ RSpec.describe Reports::TranslatorReport do
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, true)) }
 
         it 'has the expected row 6' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'FR', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '0', '0', '0', '3', '0', '0']
+          expected_results = [@start_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '3', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   @article_project.name, @article_project.job_type.titlecase, article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '0', '3', '0']
           expect(result[9]).to eql expected_results
         end
 
@@ -206,32 +206,32 @@ RSpec.describe Reports::TranslatorReport do
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, false, 'completed')) }
 
         it 'has the expected row 6' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",    'reviewer',  'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",    'reviewer',  'EN-US', 'FR', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'FR', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer', 'EN-US', 'IT',  @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer', 'EN-US', 'IT',  @article_project.name, @article_project.job_type.titlecase, article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",     'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",     'translator', 'EN-US', 'IT',   @article_project.name, @article_project.job_type.titlecase, article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[9]).to eql expected_results
         end
 
         it 'has the expected row 10' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, sha, '', commit_start, approved_at, '0', '0', '0', '3', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '3', '3', '0']
           expect(result[10]).to eql expected_results
         end
 
         it 'has the expected row 11' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '3', '3', '0']
           expect(result[11]).to eql expected_results
         end
 
@@ -249,17 +249,17 @@ RSpec.describe Reports::TranslatorReport do
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, true, 'completed')) }
 
         it 'has the expected row 6' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'FR', project, sha, '', commit_start, approved_at, '0', '0', '3', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'FR', project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[6]).to eql expected_results
         end
 
         it 'has the expected row 7' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   @article_project.name, '', article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   @article_project.name, @article_project.job_type.titlecase, article, article_start, approved_at, '0', '3', '0', '0', '0', '0']
           expect(result[7]).to eql expected_results
         end
 
         it 'has the expected row 8' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, sha, '', commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '3', '3', '0']
           expect(result[8]).to eql expected_results
         end
 

--- a/spec/lib/reports/translator_report_spec.rb
+++ b/spec/lib/reports/translator_report_spec.rb
@@ -53,18 +53,22 @@ RSpec.describe Reports::TranslatorReport do
         @languages = ['it', 'fr']
 
         @project = FactoryBot.create(:project, name: 'Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true })
-        @article_project = FactoryBot.create(:project, name: 'Article Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true }, job_type: 2)
+        @article_project = FactoryBot.create(:project, name: 'Article Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true }, job_type: 1)
+        @asset_project = FactoryBot.create(:project, name: 'Asset Foo', targeted_rfc5646_locales: { 'en-US' => true, 'fr' => true, 'it' => true }, job_type: 2)
         @commit = FactoryBot.create(:commit, project: @project, approved_at: @end_date)
         @reviewer = FactoryBot.create(:user, :reviewer, approved_rfc5646_locales: %w(it fr), first_name: 'Mark', email: 'mark@test.host')
         @translator = FactoryBot.create(:user, :translator, approved_rfc5646_locales: %w(it fr), first_name: 'Rebecca')
         @article = FactoryBot.create(:article, project: @article_project, created_at: @start_date, last_completed_at: @end_date)
+        @asset = FactoryBot.create(:asset, project: @asset_project, created_at: @start_date, approved_at: @end_date)
 
         key1 = FactoryBot.create(:key, project: @project)
         key2 = FactoryBot.create(:key, project: @project)
         key3 = FactoryBot.create(:key, project: @project)
         key4 = FactoryBot.create(:key, project: @project)
         key5 = FactoryBot.create(:key, project: @article_project)
+        key6 = FactoryBot.create(:key, project: @asset_project)
         @commit.keys << [key1, key2, key3, key4]
+        @asset.keys << [key6]
 
         t1 = FactoryBot.create(:translation, key: key1, rfc5646_locale: 'fr', tm_match: 71, source_copy: 'One two three', translation_date: @start_date, review_date: @start_date, reviewer: @reviewer, translator: @translator)
         FactoryBot.create(:translation_change, translation: t1, project: @project, sha: @commit.revision, is_edit: false, user: @translator, role: 'translator', created_at: @start_date, tm_match: t1.tm_match)
@@ -84,6 +88,10 @@ RSpec.describe Reports::TranslatorReport do
         t5 = FactoryBot.create(:translation, key: key5, rfc5646_locale: 'it', tm_match: 60, source_copy: 'One two three', translation_date: @end_date, review_date: @end_date, reviewer: @reviewer, translator: @translator)
         FactoryBot.create(:translation_change, translation: t5, project: @article_project, sha: nil, article: @article, is_edit: false, user: @translator, role: 'translator', created_at: @end_date, tm_match: t5.tm_match)
         FactoryBot.create(:translation_change, translation: t5, project: @article_project, sha: nil, article: @article, is_edit: true, user: @reviewer, role: 'reviewer', created_at: @end_date, tm_match: t5.tm_match)
+
+        t6 = FactoryBot.create(:translation, key: key6, rfc5646_locale: 'it', tm_match: 70, source_copy: 'One two three', translation_date: @end_date, review_date: @end_date, reviewer: @reviewer, translator: @translator)
+        FactoryBot.create(:translation_change, translation: t6, project: @asset_project, sha: nil, asset: @asset, is_edit: false, user: @translator, role: 'translator', created_at: @end_date, tm_match: t6.tm_match)
+        FactoryBot.create(:translation_change, translation: t6, project: @asset_project, sha: nil, asset: @asset, is_edit: true, user: @reviewer, role: 'reviewer', created_at: @end_date, tm_match: t6.tm_match)
       end
 
       context 'header info' do
@@ -112,9 +120,11 @@ RSpec.describe Reports::TranslatorReport do
         let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
+        let!(:asset) { @asset.id.to_s }
         let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
+        let!(:asset_start) { @asset.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages)) }
 
         it 'has the expected row 6' do
@@ -148,27 +158,39 @@ RSpec.describe Reports::TranslatorReport do
         end
 
         it 'has the expected row 12' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   @asset_project.name, @asset_project.job_type.titlecase, asset, asset_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[12]).to eql expected_results
         end
 
         it 'has the expected row 13' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT',   @asset_project.name, @asset_project.job_type.titlecase, asset, asset_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[13]).to eql expected_results
         end
 
         it 'has the expected row 14' do
-          expect(result[14]).to eql nil
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '0', '3', '0']
+          expect(result[14]).to eql expected_results
+        end
+
+        it 'has the expected row 15' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '0', '3', '0']
+          expect(result[15]).to eql expected_results
+        end
+
+        it 'has the expected row 16' do
+          expect(result[16]).to eql nil
         end
       end
 
-      context 'internal users' do
+      context 'exclude internal users' do
         let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
+        let!(:asset) { @asset.id.to_s }
         let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
+        let!(:asset_start) { @asset.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, true)) }
 
         it 'has the expected row 6' do
@@ -187,12 +209,17 @@ RSpec.describe Reports::TranslatorReport do
         end
 
         it 'has the expected row 9' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '0', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   @asset_project.name, @asset_project.job_type.titlecase, asset, asset_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[9]).to eql expected_results
         end
 
         it 'has the expected row 10' do
-          expect(result[10]).to eql nil
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '0', '3', '0']
+          expect(result[10]).to eql expected_results
+        end
+
+        it 'has the expected row 11' do
+          expect(result[11]).to eql nil
         end
       end
 
@@ -200,9 +227,11 @@ RSpec.describe Reports::TranslatorReport do
         let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
+        let!(:asset) { @asset.id.to_s }
         let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
+        let!(:asset_start) { @asset.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, false, 'completed')) }
 
         it 'has the expected row 6' do
@@ -226,26 +255,38 @@ RSpec.describe Reports::TranslatorReport do
         end
 
         it 'has the expected row 10' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '3', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   @asset_project.name, @asset_project.job_type.titlecase, asset, asset_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[10]).to eql expected_results
         end
 
         it 'has the expected row 11' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', @asset_project.name, @asset_project.job_type.titlecase, asset, asset_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[11]).to eql expected_results
         end
 
         it 'has the expected row 12' do
-          expect(result[12]).to eql nil
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Mark',    "#{@reviewer.id}",        'reviewer',   'EN-US', 'IT',   project, @project.job_type.titlecase, sha, commit_start, approved_at, '0', '0', '0', '3', '3', '0']
+          expect(result[12]).to eql expected_results
+        end
+
+        it 'has the expected row 13' do
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}",  'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expect(result[13]).to eql expected_results
+        end
+
+        it 'has the expected row 14' do
+          expect(result[14]).to eql nil
         end
       end
       context 'completion date version: exclude internal users' do
         let!(:article) { @article.name }
         let!(:project) { @project.name }
         let!(:sha) { @commit.revision }
+        let!(:asset) { @asset.id.to_s }
         let!(:commit_start) { @commit.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:article_start) { @article.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:approved_at) { @end_date.strftime('%Y-%m-%d %H:%M') }
+        let!(:asset_start) { @asset.created_at.strftime('%Y-%m-%d %H:%M') }
         let!(:result) { CSV.parse(Reports::TranslatorReport.generate_csv(@start_date, @end_date, @languages, true, 'completed')) }
 
         it 'has the expected row 6' do
@@ -259,12 +300,17 @@ RSpec.describe Reports::TranslatorReport do
         end
 
         it 'has the expected row 8' do
-          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', @asset_project.name, @asset_project.job_type.titlecase, asset, asset_start, approved_at, '0', '0', '3', '0', '0', '0']
           expect(result[8]).to eql expected_results
         end
 
         it 'has the expected row 9' do
-          expect(result[9]).to  eql nil
+          expected_results = [@end_date.strftime("%Y-%m-%d"), 'Rebecca', "#{@translator.id}", 'translator', 'EN-US', 'IT', project, @project.job_type.titlecase, sha, commit_start, approved_at, '3', '0', '0', '3', '3', '0']
+          expect(result[9]).to eql expected_results
+        end
+
+        it 'has the expected row 10' do
+          expect(result[10]).to  eql nil
         end
       end
     end

--- a/spec/requests/translations_spec.rb
+++ b/spec/requests/translations_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe "Translations", type: :request do
       expect(TranslationChange.first.article).to eq article
     end
 
+    it 'handles an asset in the params' do
+      project = FactoryBot.create(:project, targeted_rfc5646_locales: {'fr'=>true, 'es'=>true}, base_rfc5646_locale: 'en')
+      key1 = FactoryBot.create(:key, key: "firstkey",  project: project)
+      asset = FactoryBot.create(:asset)
+      translation = FactoryBot.create(:translation, source_rfc5646_locale: 'en', source_copy: 'fake', copy: nil, approved: nil, key: key1)
+
+      url = project_key_translation_path(project, key1, translation.to_param, asset_id: asset.id)
+      patch_via_redirect url, translation: { copy: 'fake' }
+
+      expect(response).to render_template(:edit)
+      expect(TranslationChange.first.asset).to eq asset
+    end
+
     it 'handles a project in the params' do
       project = FactoryBot.create(:project, targeted_rfc5646_locales: {'fr'=>true, 'es'=>true}, base_rfc5646_locale: 'en')
       key1 = FactoryBot.create(:key, key: "firstkey",  project: project)


### PR DESCRIPTION
This PR adds Assets to the translator report, capturing the `asset_id` in `translation_changes` and using the corresponding fields for shared columns like `Approved Date`.

It also contains another commit that includes bug fixes for loading the Asset File. The old logic assumed using Paperclip meant that the `url` should be used, however, all files are processed through Paperclip (local and S3 storage). I changed the condition to check for the local file, if it doesn't exist then the openuri logic is used.