### PR TITLE
Assets - Added ability to set targeted locales and Download Button Fix

### DIFF
--- a/app/assets/stylesheets/pages/assets.css.scss
+++ b/app/assets/stylesheets/pages/assets.css.scss
@@ -2,9 +2,42 @@
 @import "css3-mixins";
 
 body.assets {
+  .select_all_link {
+    margin: 0 10px 15px 0;
+  }
+  .deselect_all_link {
+    margin: 0 0 15px 10px;
+  }
   .control-group label {
     padding-top: 0;
     width: 170px;
+
+    &.form_checkbox {
+      display: block;
+      height: 30px;
+      float: none;
+      margin: 10px 0;
+      position: relative;
+      border: solid 1px #d2d9dd;
+      width: 97%;
+      padding: 1% 1% 1% 2%;
+
+      .locale-flag {
+        position: relative;
+        left: -1%;
+      }
+
+      span {
+        display: inline-block;
+        top: -3px;
+        position: relative;
+      }
+
+      input {
+        float: right;
+        margin-top: 7px;
+      }
+    }
   }
 
   &#assets-show, &#assets-issues {

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,3 +1,4 @@
+# Language: Ruby, Level: Level 3
 class AssetsController < ApplicationController
   respond_to :json, only: [:create, :show, :update]
   respond_to :html, only: [:create, :show, :update, :new, :edit]
@@ -147,6 +148,19 @@ private
 
   def params_for_update
     hsh = params.require(:asset).permit(:name, :description, :email, :file, :file_name)
+
+    if params[:asset].try(:key?, :targeted_rfc5646_locales)
+      locales = {}
+      params[:asset][:targeted_rfc5646_locales].each do |k,v|
+        if k.class == String && !v
+          locales.merge! JSON.parse(k.gsub('=>', ':'))
+        else
+          locales.merge! k => v
+        end
+      end
+      hsh[:targeted_rfc5646_locales] = locales
+    end
+
     hsh[:priority] = params[:asset][:priority] # default to nil
     hsh[:due_date] = DateTime::strptime(params[:asset][:due_date], "%m/%d/%Y") rescue '' if params[:asset].try(:key?, :due_date)
     hsh[:file_name] = File.basename(params[:asset][:file].original_filename, File.extname(params[:asset][:file].original_filename)) if params[:asset][:file].try(:original_filename)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -44,8 +44,8 @@ class Asset < ActiveRecord::Base
   include CommonLocaleLogic
   before_validation(on: :create) do |asset|
     if asset.project # this is needed to test validate_attachment_presence, project is null in this case for some reason
-      asset.base_rfc5646_locale      = asset.project.base_rfc5646_locale
-      asset.targeted_rfc5646_locales = asset.project.targeted_rfc5646_locales
+      asset.base_rfc5646_locale      = asset.project.base_rfc5646_locale if asset.base_rfc5646_locale.blank?
+      asset.targeted_rfc5646_locales = asset.project.targeted_rfc5646_locales if asset.targeted_rfc5646_locales.blank?
     end
   end
   # ======== END LOCALE RELATED CODE ===================================================================================

--- a/app/views/assets/_form.html.slim
+++ b/app/views/assets/_form.html.slim
@@ -40,6 +40,7 @@
             .controls
               = f.file_field :file, class: 'tooltip-parent', 'data-tooltip' => '#asset-file'
               .qtip-tooltip#asset-file The asset requires a file.
+
         .control-group
           = f.label :priority, class: 'control-label'
           .controls
@@ -56,14 +57,29 @@
             = (@asset.persisted? ? @asset : @project).base_rfc5646_locale
 
         .control-group
-          = f.label :required_rfc5646_locales, 'Required Localizations', class: 'control-label'
+          = f.label :targeted_rfc5646_locales, 'Required Localizations', class: 'control-label'
           .controls
-            = (@asset.persisted? ? @asset : @project).required_rfc5646_locales.join(', ').presence || '-'
+            a.select_all_link href="#" Select All
+            | |
+            a.deselect_all_link href="#" Deselect All
+            - @project.targeted_rfc5646_locales.select { |k,v| v == true}.each do |key, value|
+              label.form_checkbox
+                = check_box_tag 'asset[targeted_rfc5646_locales][]', { key => value }, @asset.targeted_rfc5646_locales.include?(key)
+                span = key.upcase
 
         .control-group
-          = f.label :other_rfc5646_locales, 'Other Localizations', class: 'control-label'
+          = f.label :targeted_rfc5646_locales, 'Other Localizations', class: 'control-label'
           .controls
-            = (@asset.persisted? ? @asset : @project).other_rfc5646_locales.join(', ').presence || '-'
+            - if @project.targeted_rfc5646_locales.select { |k,v| v == false}.presence
+              a.select_all_link href="#" Select All
+              | |
+              a.deselect_all_link href="#" Deselect All
+              - @project.targeted_rfc5646_locales.select { |k,v| v == false}.each do |key, value|
+                label.form_checkbox
+                  = check_box_tag 'asset[targeted_rfc5646_locales][]', { key => value }, @asset.targeted_rfc5646_locales.include?(key)
+                  span = key.upcase
+            - else
+              | -
 
         .control-group
           = f.label :email, class: 'control-label'
@@ -80,3 +96,10 @@
   .form-actions
     = f.submit class: 'primary', value: 'save', data: { confirm: 'Are you sure?  Changes are irreversible.'}
     button.default href=(@asset.persisted? ? project_asset_path(@project, @asset) : root_path) Cancel
+
+
+- content_for :javascript do
+  script type='text/javascript'
+    - file_name = 'views/assets/_form'
+    - js_coffee_erb_file  = Rails.root.join('app', file_name + '.js.coffee.erb')
+    = raw(CoffeeScript.compile(ERB.new(File.read(js_coffee_erb_file)).result(binding))) if File.exist?(js_coffee_erb_file)

--- a/app/views/assets/_form.js.coffee.erb
+++ b/app/views/assets/_form.js.coffee.erb
@@ -1,0 +1,33 @@
+$ ->
+  setFlag = (element) ->
+    $element = $(element)
+    $element.find('img.locale-flag').remove()
+    image = Locale.from_rfc5646($element.text())?.image()
+    if image
+      img = $('<img/>').attr('src', image).addClass('locale-flag')
+      $element.prepend(img)
+      img.css('top', ($element.height() - 24) / 2)
+
+
+  setFlags = ->
+    $('.form_checkbox').each ->
+      setFlag(@)
+
+  $('.select_all_link').click (e) ->
+    e.preventDefault()
+
+    $parent = $(@).parent()
+    $('.form_checkbox', $parent).each ->
+      $('input[type=checkbox]', $parent).prop('checked', true)
+
+  $('.deselect_all_link').click (e) ->
+    e.preventDefault()
+
+    $parent = $(@).parent()
+    $('.form_checkbox', $parent).each ->
+      $('input[type=checkbox]', $parent).prop('checked', false)
+
+  if (window.localesLoaded)
+    setFlags()
+  else
+    $(document).bind('locales_loaded', setFlags)

--- a/lib/exporter/asset.rb
+++ b/lib/exporter/asset.rb
@@ -65,12 +65,11 @@ module Exporter
 private
     def generate_xlsx(asset, locale)
       if File.file?(asset.file.path)
-        RubyXL::Parser.parse(asset.file.path)
+        workbook = RubyXL::Parser.parse(asset.file.path)
       else
         content = open(asset.file.url).read
-        RubyXL::Parser.parse_buffer(content)
+        workbook = RubyXL::Parser.parse_buffer(content)
       end
-      workbook = RubyXL::Parser.parse(asset.file.path)
 
       asset.translations.in_locale(locale).each do |translation|
         cell_info = translation.key.original_key.scan(/sheet(\d+)-row(\d+)-col(\d+)/).flatten

--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -56,8 +56,7 @@ module Reports
           asset = (tc.asset_id.blank?) ? nil : tc.asset_id
           job_start = (tc.job_start ? tc.job_start.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
           approved_at = (tc.approved_at ? tc.approved_at.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
-
-          p (sha || article || asset).to_s
+          
           csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.source_rfc5646_locale.upcase, tc.rfc5646_locale.upcase, tc.project_name, Project.job_types.key(tc.job_type).titlecase, (sha || article || asset).to_s, job_start, approved_at, counts].flatten
         end
       end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -33,21 +33,21 @@ RSpec.describe AssetsController, type: :controller do
       expect(asset.targeted_locales.map(&:rfc5646)).to match_array(%w(es fr))
     end
 
-    it "creates an Asset specifying targeted_rfc5646_locales, but the project's are used" do
+    it "creates an Asset specifying targeted_rfc5646_locales" do
       post :create, project_id: @project, asset: FactoryBot.attributes_for(:asset, targeted_rfc5646_locales: { 'ja' => true }), format: :json
       expect(response.status).to eql(200)
       expect(Asset.count).to eql(1)
       asset = Asset.last
-      expect(asset.targeted_rfc5646_locales).to eql(@project.targeted_rfc5646_locales)
+      expect(asset.targeted_rfc5646_locales).to eql({ 'ja' => true })
     end
 
-    it "creates an Asset specifying base_locale, but the project's are used" do
+    it "creates an Asset specifying base_locale" do
       post :create, project_id: @project, asset: FactoryBot.attributes_for(:asset, base_rfc5646_locale: 'ja'), format: :json
       expect(response.status).to eql(200)
       expect(Asset.count).to eql(1)
       asset = Asset.last
-      expect(asset.base_rfc5646_locale).to eql('en')
-      expect(asset.base_locale).to eql(Locale.from_rfc5646('en'))
+      expect(asset.base_rfc5646_locale).to eql('ja')
+      expect(asset.base_locale).to eql(Locale.from_rfc5646('ja'))
     end
 
     it "doesn't create a Asset in a Project with a duplicate key name" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Asset, type: :model do
       expect(asset.targeted_rfc5646_locales).to eql({'fr' => true})
     end
 
-    it 'should not use targeted_rfc5646_locales specified, but revert to projects (due to key associations)' do
+    it 'should use targeted_rfc5646_locales specified' do
       project = FactoryBot.create(:project, targeted_rfc5646_locales: {'fr' => true})
       asset = FactoryBot.create(:asset, targeted_rfc5646_locales: {'it' => true}, project: project)
-      expect(asset.targeted_rfc5646_locales).to eql({'fr' => true})
+      expect(asset.targeted_rfc5646_locales).to eql({'it' => true})
     end
   end
 

--- a/spec/workers/asset_xlsx_importer_spec.rb
+++ b/spec/workers/asset_xlsx_importer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AssetXlsxImporter do
     before :each do
       allow_any_instance_of(AssetImporter::Finisher).to receive(:on_success) # prevent import from finishing
       @asset = FactoryBot.create(:asset)
-      AssetXlsxImporter.new.perform(@asset.id)
+      AssetXlsxImporter.new.import(@asset.id)
       @asset.reload
     end
 
@@ -37,7 +37,7 @@ RSpec.describe AssetXlsxImporter do
     end
 
     it 'sets the key to the correct name' do
-      expect(@asset.keys.first.key).to eq "#{@asset.file_name.downcase}-sheet1-row1-col1"
+      expect(@asset.keys.first.key).to eq "#{@asset.id}-#{@asset.file_name.downcase}-sheet0-row1-col1"
     end
   end
 end


### PR DESCRIPTION
This PR contains 2 commits, the first is the locale selection for assets. Previously, you were restricted to only using the projects locales.

The second commit is a fix for the download button on an Asset. There was a single bad line, line 73 in `lib/exporter/asset.rb`. I've rewritten the logic to accept local or S3 hosted Excel files.