### PR TITLE
Fixed leveraging translations and fixed locale selection for Assets

### DIFF
--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -219,17 +219,20 @@ class Key < ActiveRecord::Base
   # This is used, for example, when a Project adds a new required localization,
   # to create pending Translation requests for each string in the new locale.
 
-  def add_pending_translations
-    translations.in_locale(base_locale).find_or_create!(
+  def add_pending_translations(model = nil)
+    locales = model && model.targeted_locales ? model.targeted_locales : targeted_locales
+    base = model && model.base_locale ? model.base_locale : base_locale
+
+    translations.in_locale(base).find_or_create!(
         source_copy:              source_copy,
         copy:                     source_copy,
-        source_locale:            base_locale,
-        locale:                   base_locale,
+        source_locale:            base,
+        locale:                   base,
         approved:                 true,
         preserve_reviewed_status: true,
     )
 
-    targeted_locales.each do |locale|
+    locales.each do |locale|
       next if skip_key?(locale)
       t = translations.in_locale(locale).find_or_create!(
         source_copy:          source_copy,

--- a/spec/workers/asset_xlsx_importer_spec.rb
+++ b/spec/workers/asset_xlsx_importer_spec.rb
@@ -17,8 +17,8 @@ require 'rails_helper'
 RSpec.describe AssetXlsxImporter do
   describe "#perform" do
     before :each do
-      allow_any_instance_of(AssetImporter::Finisher).to receive(:on_success) # prevent import from finishing
-      @asset = FactoryBot.create(:asset)
+      @project = FactoryBot.create(:project, targeted_rfc5646_locales: { 'es' => true })
+      @asset = FactoryBot.create(:asset, targeted_rfc5646_locales: { 'fr' => true }, project: @project)
       AssetXlsxImporter.new.import(@asset.id)
       @asset.reload
     end
@@ -37,7 +37,9 @@ RSpec.describe AssetXlsxImporter do
     end
 
     it 'sets the key to the correct name' do
-      expect(@asset.keys.first.key).to eq "#{@asset.id}-#{@asset.file_name.downcase}-sheet0-row1-col1"
+      expect(@asset.keys.count).to eq 1
+      hashed_value = Digest::SHA1.hexdigest(@asset.keys.first.source_copy)
+      expect(@asset.keys.first.key).to eq "#{@asset.file_name.downcase}-sheet0-row1-col1-#{hashed_value}"
     end
   end
 end


### PR DESCRIPTION
This PR solves the two outstanding Excel issues. The first is locale selection can now be different from the project for an Asset, previously this wasn't working correctly. The last issue is with leveraging translations, which now will work for a file that is uploaded more than once. 

Note that leveraging only works based on the **same file** and the **same location** of the cell in the workbook. If you want leveraging to occur and you need to add something to the file, do so at the end of the rows or columns. If you put something in say the first row, it will throw off the automatic translations. We discussed this at length, and the correct approach would be to fully change the key to not include the cell location. This approach is out of scope as the original spec stated the location be part of the key. This change would require quite a bit of work for building the resulting Excel files. 