### PR TITLE
Reasons Modal Changes

### DIFF
--- a/app/assets/javascripts/application/translation_workbench.js.coffee.erb
+++ b/app/assets/javascripts/application/translation_workbench.js.coffee.erb
@@ -192,7 +192,7 @@ class TranslationItem
 
       if first
         severity = first.reason_severity
-        if severity
+        if severity != null
           context.reason_severity = {
             class_name: severity_classes[severity],
             severity: severity
@@ -625,7 +625,7 @@ class root.TranslationWorkbench
     $(document).on 'leanModal.hidden', ->
       # remove the fix to prevent users from scrolling the background
       $('body').css({'overflow-y':''})
-      
+
       $btn_badge = $('.reason-btn .badge')
       $btn_badge.text('0')
       workbench.reasonSeverity = null

--- a/app/assets/javascripts/application/translation_workbench.js.coffee.erb
+++ b/app/assets/javascripts/application/translation_workbench.js.coffee.erb
@@ -594,6 +594,9 @@ class root.TranslationWorkbench
         $trans.focus()
 
     $(document).on 'leanModal.shown', ->
+      # prevent users from scrolling the background
+      $('body').css({'overflow-y':'hidden'})
+
       $modal = $('#add-translation-reasons')
       $reasonBadgeArea = $('.translation-area.active').parent().find('.reason-badges')
       $severityBadge = $reasonBadgeArea.find('.severity-badge')
@@ -620,6 +623,9 @@ class root.TranslationWorkbench
         )
 
     $(document).on 'leanModal.hidden', ->
+      # remove the fix to prevent users from scrolling the background
+      $('body').css({'overflow-y':''})
+      
       $btn_badge = $('.reason-btn .badge')
       $btn_badge.text('0')
       workbench.reasonSeverity = null

--- a/app/assets/javascripts/application/translation_workbench.js.coffee.erb
+++ b/app/assets/javascripts/application/translation_workbench.js.coffee.erb
@@ -631,3 +631,7 @@ class root.TranslationWorkbench
       $('#dropdown-search').val('')
       $('.dropdown-menu li:not(.no-padding)', $modal).fadeIn('fast')
       $('input[type=checkbox]', $modal).prop 'checked', false
+
+    $(document).keyup (ev) ->
+      if (ev.keyCode == 27)
+        $("#lean_overlay").trigger("click");


### PR DESCRIPTION
This PR contains three fixes for the Reasons Workflow:

- The Modal now closes when the user hits the ESC key. All other methods of closing the window still apply (such as clicking on the backdrop). Hitting ESC emulates clicking the backdrop, and simple hides the window without saving or undoing.
- When a user would come to the end of a dropdown list (like the reasons selections), they would inadvertently scroll the page in the background. This no longer happens on the Translation Workbench.
- If the severity selection was set to Minor, it looked like it didn't save. It was saved, just not re-rendered.  This has been corrected.

All of these changes are for the Translation Workbench only. I didn't touch the main leanModal in the process, so there shouldn't be any adverse affects.