### PR TITLE
Translation Edit screen reasons

### DIFF
--- a/app/assets/javascripts/application/reasons_modal.js.coffee.erb
+++ b/app/assets/javascripts/application/reasons_modal.js.coffee.erb
@@ -6,10 +6,27 @@ class root.ReasonsModal
     @reasonSeverityClasses = ['badge-success', 'badge-info', 'badge-warning', 'badge-danger']
     @setupReasonsModal()
 
-  closeModal: =>
+  closeModal: ->
     $modal = $('#add-translation-reasons')
     $('[data-toggle="popover"]', $modal).popover('hide')
     $('.close', $modal).click()
+
+  removeTempBadges: =>
+    $trans = $(@translation_selector)
+    $reasonBadgeArea = $trans.parent().find('.reason-badges')
+    # only go after a saved severity badge, non-saved ones will be removed
+    $severityBadge = $reasonBadgeArea.find('.severity-badge.saved')
+
+    # remove the badges from the active item
+    $('.badge:not(.saved)', $reasonBadgeArea).remove()
+
+    # handle reason severity
+    @reasonSeverity = $('#original_severity').val()
+
+    $severityBadge.text($('#original_severity_text').val())
+      .data('severity', @reasonSeverity)
+      .removeClass(@reasonSeverityClasses.join(' '))
+      .addClass(@reasonSeverityClasses[@reasonSeverity])
 
   setupReasonsModal: ->
     $modal = $('#add-translation-reasons')
@@ -109,21 +126,7 @@ class root.ReasonsModal
           $(this).fadeOut('fast')
 
     $('.undo-btn', $modal).on 'click', ->
-      $trans = $(modal.translation_selector)
-      $reasonBadgeArea = $trans.parent().find('.reason-badges')
-      # only go after a saved severity badge, non-saved ones will be removed
-      $severityBadge = $reasonBadgeArea.find('.severity-badge.saved')
-
-      # remove the badges from the active item
-      $('.badge:not(.saved)', $reasonBadgeArea).remove()
-
-      # handle reason severity
-      modal.reasonSeverity = $('#original_severity').val()
-
-      $severityBadge.text($('#original_severity_text').val())
-        .data('severity', modal.reasonSeverity)
-        .removeClass(modal.reasonSeverityClasses.join(' '))
-        .addClass(modal.reasonSeverityClasses[modal.reasonSeverity])
+      modal.removeTempBadges()
 
       # raise an custom undo event
       $.event.trigger 'reasonsModal.undo'
@@ -172,6 +175,9 @@ class root.ReasonsModal
     $(document).on 'leanModal.hidden', ->
       # remove the fix to prevent users from scrolling the background
       $('body').css({'overflow-y':''})
+
+      # remove temporary button badges
+      modal.removeTempBadges()
 
       $btn_badge = $('.reason-btn .badge')
       $btn_badge.text('0')

--- a/app/assets/javascripts/application/reasons_modal.js.coffee.erb
+++ b/app/assets/javascripts/application/reasons_modal.js.coffee.erb
@@ -1,0 +1,191 @@
+root = exports ? this
+
+class root.ReasonsModal
+  constructor: (@translation_selector) ->
+    @reasonSeverity = null
+    @reasonSeverityClasses = ['badge-success', 'badge-info', 'badge-warning', 'badge-danger']
+    @setupReasonsModal()
+
+  closeModal: =>
+    $modal = $('#add-translation-reasons')
+    $('[data-toggle="popover"]', $modal).popover('hide')
+    $('.close', $modal).click()
+
+  setupReasonsModal: ->
+    $modal = $('#add-translation-reasons')
+    modal = this
+
+    $('[data-toggle="tooltip"]', $modal).tooltip()
+    $('[data-toggle="popover"]', $modal).popover
+      html: true
+      content: ->
+        content = $(this).attr('data-popover-content')
+        $(content).children('.popover-body').html()
+      title: ->
+        title = $(this).attr('data-popover-content')
+        $(title).children('.popover-heading').html()
+
+    $('[data-severity]', $modal).on 'click', (event) ->
+      event.preventDefault()
+      $this = $(this)
+      $prev = $this.parent().prev()
+      $save_btn = $('.save-btn', $modal)
+      $severityLabel = $('#reason-review-popover .popover-body .severity-label')
+      $area = $(modal.translation_selector).parent().find('.reason-badges')
+      severityText = "Severity: #{$this.text()}"
+
+      # set the text and data attr of the button
+      $prev.text(severityText)
+      $prev.data('severity', $this.data('severity'))
+
+      # update review
+      $severityLabel.text(severityText)
+
+      # update the reasonSeverity variable
+      modal.reasonSeverity = $this.data('severity')
+
+      # see if we should update the save button
+      $save_btn.removeAttr('disabled') if $('input:checked', $modal).length
+
+      # add the severity badge
+      $severityBadge = $('.severity-badge', $area)
+      if $severityBadge.length
+        $severityBadge.text(severityText)
+          .data('severity', modal.reasonSeverity)
+          .removeClass(modal.reasonSeverityClasses.join(' '))
+          .addClass(modal.reasonSeverityClasses[modal.reasonSeverity])
+      else
+        $area.prepend(
+          "<span class=\"badge #{modal.reasonSeverityClasses[modal.reasonSeverity]} severity-badge\"
+          data-severity=\"#{modal.reasonSeverity}\">#{severityText}</span>"
+        )
+
+    $modal.on 'shown.bs.dropdown', ->
+      $('#dropdown-search').focus()
+
+    # modal drop-drop down checkboxes
+    # handle clicking on a li and checking/unchecking the checkbox
+    # and update the UI (badges, review, and button badge (count))
+    $('.dropdown-menu li:not(.no-padding)', $modal).on 'click', (event) ->
+      $target = $(event.currentTarget)
+      $inp = $target.find('input[type=checkbox]')
+      return unless $inp.length
+      text = $inp.parent().text()
+      $area = $(modal.translation_selector).parent().find('.reason-badges')
+      $btn_badge = $('.reason-btn .badge')
+      $review = $('#reason-review-popover .popover-body ul')
+      $save_btn = $('.save-btn', $modal)
+
+      setTimeout ->
+        $inp.prop 'checked', !$inp.prop('checked')
+        checked = $inp.prop('checked')
+        if checked
+          $save_btn.removeAttr('disabled') if modal.reasonSeverity != null
+          $area.append(
+            "<span class=\"badge badge-secondary\"
+            data-checkbox=\"#{$inp.val()}\">#{text}</span>"
+          )
+          $review.append("<li data-checkbox=\"#{$inp.val()}\">#{text}</li>")
+          $btn_badge.text(parseInt($btn_badge.text()) + 1)
+        else
+          item_count = parseInt(parseInt($btn_badge.text()) - 1)
+          $save_btn.attr('disabled', 'disabled') unless item_count && modal.reasonSeverity != null
+          $area.find(".badge[data-checkbox='#{$inp.val()}']:not(.saved)").remove()
+          $review.find("[data-checkbox='#{$inp.val()}']").remove()
+          $btn_badge.text(item_count)
+      , 0
+
+      $(event.target).blur()
+      false
+
+    $('#dropdown-search', $modal).on 'keyup', ->
+      search_regex = new RegExp(this.value, 'i')
+      $('.dropdown-menu li:not(.no-padding)', $modal).each ->
+        $this = $(this)
+        string_value = "#{$this.text()} #{$('i', $this).data('original-title')}"
+        if search_regex.test string_value
+          $(this).fadeIn('fast')
+        else
+          $(this).fadeOut('fast')
+
+    $('.undo-btn', $modal).on 'click', ->
+      $trans = $(modal.translation_selector)
+      $reasonBadgeArea = $trans.parent().find('.reason-badges')
+      # only go after a saved severity badge, non-saved ones will be removed
+      $severityBadge = $reasonBadgeArea.find('.severity-badge.saved')
+
+      # remove the badges from the active item
+      $('.badge:not(.saved)', $reasonBadgeArea).remove()
+
+      # handle reason severity
+      modal.reasonSeverity = $('#original_severity').val()
+
+      $severityBadge.text($('#original_severity_text').val())
+        .data('severity', modal.reasonSeverity)
+        .removeClass(modal.reasonSeverityClasses.join(' '))
+        .addClass(modal.reasonSeverityClasses[modal.reasonSeverity])
+
+      # raise an custom undo event
+      $.event.trigger 'reasonsModal.undo'
+      modal.closeModal()
+
+    $('.save-btn', $modal).on 'click', =>
+      $trans = $(modal.translation_selector)
+
+      reason_ids = $('input:checked', $modal).map ->
+        this.value
+
+      if reason_ids.length && modal.reasonSeverity != null
+        # raise an custom save event
+        $.event.trigger 'reasonsModal.save', [reason_ids.toArray(), modal.reasonSeverity]
+        modal.closeModal()
+
+    $(document).on 'leanModal.shown', ->
+      # prevent users from scrolling the background
+      $('body').css({'overflow-y':'hidden'})
+
+      $modal = $('#add-translation-reasons')
+      $reasonBadgeArea = $(modal.translation_selector).parent().find('.reason-badges')
+      $severityBadge = $reasonBadgeArea.find('.severity-badge')
+      $badges = $reasonBadgeArea.find('.badge:not(.severity-badge):not(.saved)')
+      $btn_badge = $('.reason-btn .badge')
+      $review = $('#reason-review-popover .popover-body ul')
+      $severityLabel = $('.severity-label', $review)
+
+      if $severityBadge.length
+        modal.reasonSeverity = $severityBadge.data('severity')
+        $('.severity-btn', $modal).text($severityBadge.text())
+          .data('severity', modal.reasonSeverity)
+        $severityLabel.text($severityBadge.text())
+        $('#original_severity').val(modal.reasonSeverity)
+        $('#original_severity_text').val($severityBadge.text())
+
+      $('.save-btn', $modal).removeAttr('disabled') if $badges.length && modal.reasonSeverity != null
+
+      for badge in $badges
+        $modal.find("[value=#{$(badge).data('checkbox')}]").prop 'checked', true
+        $btn_badge.text(parseInt($btn_badge.text()) + 1)
+        $review.append("<li data-checkbox=\"#{$(badge).data('checkbox')}\">
+          #{$(badge).text()}</li>"
+        )
+
+    $(document).on 'leanModal.hidden', ->
+      # remove the fix to prevent users from scrolling the background
+      $('body').css({'overflow-y':''})
+
+      $btn_badge = $('.reason-btn .badge')
+      $btn_badge.text('0')
+      modal.reasonSeverity = null
+      $severityLabel = $('#reason-review-popover .popover-body .severity-label')
+      $severityLabel.text('Severity Not Selected')
+      $('.severity-btn', $modal).text('Select Severity')
+      $('.save-btn', $modal).attr('disabled', 'disabled')
+      $('#reason-review-popover .popover-body ul li:not(.severity-label)').remove()
+      $('#dropdown-search').val('')
+      $('.dropdown-menu li:not(.no-padding)', $modal).fadeIn('fast')
+      $('input[type=checkbox]', $modal).prop 'checked', false
+
+    # close modal on ESC key press
+    $(document).keyup (ev) ->
+      if (ev.keyCode == 27)
+        $("#lean_overlay").trigger("click");

--- a/app/assets/javascripts/application/translation_workbench.js.coffee.erb
+++ b/app/assets/javascripts/application/translation_workbench.js.coffee.erb
@@ -132,7 +132,7 @@ class TranslationItem
   # @private
   build: ->
     severity_texts = <%= TranslationChange.reason_severities.map {|s| s[0].titlecase} %>
-    severity_classes = ['badge-success', 'badge-info', 'badge-warning', 'badge-danger']
+    severity_classes = <%= TranslationChange::SEVERITY_CLASSES %>
     context = {}
 
     context.status = @translation.status
@@ -177,6 +177,7 @@ class TranslationItem
       reasons = @translation.changes.map (change) ->
         change.reasons.map (reason) ->
           id: reason.id,
+          date: change.created_at,
           text: "#{reason.category}: #{reason.name}"
       # flatten array of reasons
       reasons = reasons.reduce(((a, b) ->
@@ -188,16 +189,18 @@ class TranslationItem
 
       context.reasons = reasons
 
-      [first, ...] = @translation.changes
+      @translation.changes.sort (a,b) ->
+        new Date(b.created_at) - new Date(a.created_at)
 
-      if first
-        severity = first.reason_severity
-        if severity != null
-          context.reason_severity = {
-            class_name: severity_classes[severity],
-            severity: severity
-            severity_text: "Severity: #{severity_texts[severity]}"
-          }
+      last_severity_change = @translation.changes.filter (t) -> t.reason_severity != null
+
+      if last_severity_change.length
+        severity = last_severity_change[0].reason_severity
+        context.reason_severity = {
+          class_name: severity_classes[severity],
+          severity: severity
+          severity_text: "Severity: #{severity_texts[severity]}"
+        }
 
 
     @element = $(HoganTemplates['translationworkbench/translation_item'].render(context))
@@ -456,188 +459,27 @@ class root.TranslationWorkbench
         previousItem = item
     @list.find(".translation-area").autosize()
 
+  # @private
   setupReasonsModal: ->
-    $modal = $('#add-translation-reasons')
-    workbench = this
-
-    $('[data-toggle="tooltip"]', $modal).tooltip()
-    $('[data-toggle="popover"]', $modal).popover
-      html: true
-      content: ->
-        content = $(this).attr('data-popover-content')
-        $(content).children('.popover-body').html()
-      title: ->
-        title = $(this).attr('data-popover-content')
-        $(title).children('.popover-heading').html()
-
-    $('[data-severity]', $modal).on 'click', (event) ->
-      event.preventDefault()
-      $this = $(this)
-      $prev = $this.parent().prev()
-      $save_btn = $('.save-btn', $modal)
-      $severityLabel = $('#reason-review-popover .popover-body .severity-label')
-      $area = $('.translation-area.active').parent().find('.reason-badges')
-      severityText = "Severity: #{$this.text()}"
-
-      # set the text and data attr of the button
-      $prev.text(severityText)
-      $prev.data('severity', $this.data('severity'))
-
-      # update review
-      $severityLabel.text(severityText)
-
-      # update the reasonSeverity variable
-      workbench.reasonSeverity = $this.data('severity')
-
-      # see if we should update the save button
-      $save_btn.removeAttr('disabled') if $('input:checked', $modal).length
-
-      # add the severity badge
-      $severityBadge = $('.severity-badge', $area)
-      if $severityBadge.length
-        $severityBadge.text(severityText)
-          .data('severity', workbench.reasonSeverity)
-          .removeClass(workbench.reasonSeverityClasses.join(' '))
-          .addClass(workbench.reasonSeverityClasses[workbench.reasonSeverity])
-      else
-        $area.prepend(
-          "<span class=\"badge #{workbench.reasonSeverityClasses[workbench.reasonSeverity]} severity-badge\"
-          data-severity=\"#{workbench.reasonSeverity}\">#{severityText}</span>"
-        )
-
-    $modal.on 'shown.bs.dropdown', ->
-      $('#dropdown-search').focus()
-
-    # modal drop-drop down checkboxes
-    # handle clicking on a li and checking/unchecking the checkbox
-    # and update the UI (badges, review, and button badge (count))
-    $('.dropdown-menu li:not(.no-padding)', $modal).on 'click', (event) ->
-      $target = $(event.currentTarget)
-      $inp = $target.find('input[type=checkbox]')
-      return unless $inp.length
-      text = $inp.parent().text()
-      $area = $('.translation-area.active').parent().find('.reason-badges')
-      $btn_badge = $('.reason-btn .badge')
-      $review = $('#reason-review-popover .popover-body ul')
-      $save_btn = $('.save-btn', $modal)
-
-      setTimeout ->
-        $inp.prop 'checked', !$inp.prop('checked')
-        checked = $inp.prop('checked')
-        if checked
-          $save_btn.removeAttr('disabled') if workbench.reasonSeverity != null
-          $area.append(
-            "<span class=\"badge badge-secondary\"
-            data-checkbox=\"#{$inp.val()}\">#{text}</span>"
-          )
-          $review.append("<li data-checkbox=\"#{$inp.val()}\">#{text}</li>")
-          $btn_badge.text(parseInt($btn_badge.text()) + 1)
-        else
-          item_count = parseInt(parseInt($btn_badge.text()) - 1)
-          $save_btn.attr('disabled', 'disabled') unless item_count && workbench.reasonSeverity != null
-          $area.find(".badge[data-checkbox='#{$inp.val()}']:not(.saved)").remove()
-          $review.find("[data-checkbox='#{$inp.val()}']").remove()
-          $btn_badge.text(item_count)
-      , 0
-
-      $(event.target).blur()
-      false
-
-    $('#dropdown-search').on 'keyup', ->
-      search_regex = new RegExp(this.value, 'i')
-      $('.dropdown-menu li:not(.no-padding)', $modal).each ->
-        $this = $(this)
-        string_value = "#{$this.text()} #{$('i', $this).data('original-title')}"
-        if search_regex.test string_value
-          $(this).fadeIn('fast')
-        else
-          $(this).fadeOut('fast')
-
-    $('.undo-btn', $modal).on 'click', =>
+    # handle undo
+    $(document).on 'reasonsModal.undo', =>
       $trans = $('.translation-area.active')
-      $reasonBadgeArea = $trans.parent().find('.reason-badges')
-      $severityBadge = $reasonBadgeArea.find('.severity-badge')
-
-      # handle reason severity
-      workbench.reasonSeverity = $('#original_severity').val()
-      $severityBadge.text($('#original_severity_text').val())
-        .data('severity', workbench.reasonSeverity)
-        .removeClass(workbench.reasonSeverityClasses.join(' '))
-        .addClass(workbench.reasonSeverityClasses[workbench.reasonSeverity])
-
-      $trans.parent().find('.badge:not(.saved)').remove()
+      # revert the translation
       item = @items.find (item) ->
         item.copy_field.hasClass 'active'
       $trans.val(item.translation.copy)
-
-      # close the modal window
-      $('#add-translation-reasons .close').click()
-
       # update the UI
       $trans.keyup()
       $trans.focus()
 
-    $('.save-btn', $modal).on 'click', =>
-      $modal = $('#add-translation-reasons')
+    $(document).on 'reasonsModal.save', (e, reason_ids, reason_severity) =>
       $trans = $('.translation-area.active')
-
+      # find the item and save it
       item = @items.find (item) ->
         item.copy_field.hasClass 'active'
 
-      reason_ids = $('input:checked', $modal).map ->
-        this.value
+      item.saveTranslation(item.translation, item.element, reason_ids, reason_severity)
 
-      if reason_ids.length
-        item.saveTranslation(item.translation, item.element, reason_ids.toArray(), workbench.reasonSeverity)
-        $('.close', $modal).click()
-        $trans.keyup()
-        $trans.focus()
-
-    $(document).on 'leanModal.shown', ->
-      # prevent users from scrolling the background
-      $('body').css({'overflow-y':'hidden'})
-
-      $modal = $('#add-translation-reasons')
-      $reasonBadgeArea = $('.translation-area.active').parent().find('.reason-badges')
-      $severityBadge = $reasonBadgeArea.find('.severity-badge')
-      $badges = $reasonBadgeArea.find('.badge:not(.severity-badge):not(.saved)')
-      $btn_badge = $('.reason-btn .badge')
-      $review = $('#reason-review-popover .popover-body ul')
-      $severityLabel = $('.severity-label', $review)
-
-      if $severityBadge.length
-        workbench.reasonSeverity = $severityBadge.data('severity')
-        $('.severity-btn', $modal).text($severityBadge.text())
-          .data('severity', workbench.reasonSeverity)
-        $severityLabel.text($severityBadge.text())
-        $('#original_severity').val(workbench.reasonSeverity)
-        $('#original_severity_text').val($severityBadge.text())
-
-      $('.save-btn', $modal).removeAttr('disabled') if $badges.length && workbench.reasonSeverity != null
-
-      for badge in $badges
-        $modal.find("[value=#{$(badge).data('checkbox')}]").prop 'checked', true
-        $btn_badge.text(parseInt($btn_badge.text()) + 1)
-        $review.append("<li data-checkbox=\"#{$(badge).data('checkbox')}\">
-          #{$(badge).text()}</li>"
-        )
-
-    $(document).on 'leanModal.hidden', ->
-      # remove the fix to prevent users from scrolling the background
-      $('body').css({'overflow-y':''})
-
-      $btn_badge = $('.reason-btn .badge')
-      $btn_badge.text('0')
-      workbench.reasonSeverity = null
-      $severityLabel = $('#reason-review-popover .popover-body .severity-label')
-      $severityLabel.text('Severity Not Selected')
-      $('.severity-btn', $modal).text('Select Severity')
-      $('.save-btn', $modal).attr('disabled', 'disabled')
-      $('#reason-review-popover .popover-body ul li:not(.severity-label)').remove()
-      $('#dropdown-search').val('')
-      $('.dropdown-menu li:not(.no-padding)', $modal).fadeIn('fast')
-      $('input[type=checkbox]', $modal).prop 'checked', false
-
-    $(document).keyup (ev) ->
-      if (ev.keyCode == 27)
-        $("#lean_overlay").trigger("click");
+      # update the UI
+      $trans.keyup()
+      $trans.focus()

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -59,3 +59,4 @@
 @import "partials/worker_status";
 @import "partials/highlighter";
 @import "partials/issues";
+@import "partials/reasons_modal";

--- a/app/assets/stylesheets/pages/projects.css.scss
+++ b/app/assets/stylesheets/pages/projects.css.scss
@@ -59,53 +59,6 @@ body.projects {
 
   .translation-workbench {
     border-top: 1px solid #dfdfdf;
-
-    .badge {
-      margin-left: 3px;
-    }
-  }
-
-  .modal {
-    * {
-      box-sizing: border-box;
-    }
-
-    ul.dropdown-menu {
-      height: 400px;
-      overflow: scroll;
-      padding: 0 15px;
-      min-width: 275px;
-
-      li {
-        padding: 10px;
-
-        &.no-padding {
-          padding: 0;
-          margin: 0 -15px 10px;
-        }
-        #dropdown-search {
-          border: none;
-          outline: none;
-          background: #ededed;
-          font-size: 1.1rem;
-          height: 50px;
-        }
-      }
-    }
-
-    .pull-left {
-      margin-right: 20px;
-    }
-
-    button {
-      &.pull-right {
-        margin-left: 20px;
-      }
-
-      .badge-left {
-        margin: 0 10px 0 0;
-      }
-    }
   }
 
   &#projects-show {
@@ -221,23 +174,6 @@ body.projects {
     ul {
       list-style-type: disc;
       margin-left: 20px;
-    }
-  }
-
-  .tooltip.show {
-    display: block;
-    z-index: 99999;
-  }
-  .popover {
-    z-index: 99999;
-
-    .popover-header {
-      margin: 0;
-    }
-
-    ul {
-      list-style-type: square;
-      padding: 0 20px;
     }
   }
 }

--- a/app/assets/stylesheets/partials/_reasons_modal.scss
+++ b/app/assets/stylesheets/partials/_reasons_modal.scss
@@ -1,0 +1,67 @@
+#add-translation-reasons {
+  * {
+    box-sizing: border-box;
+  }
+
+  ul.dropdown-menu {
+    height: 400px;
+    overflow: scroll;
+    padding: 0 15px;
+    min-width: 275px;
+
+    li {
+      padding: 10px;
+
+      &.no-padding {
+        padding: 0;
+        margin: 0 -15px 10px;
+      }
+      #dropdown-search {
+        border: none;
+        outline: none;
+        background: #ededed;
+        font-size: 1.1rem;
+        height: 50px;
+      }
+    }
+  }
+
+  .pull-left {
+    margin-right: 20px;
+  }
+
+  button {
+    &.pull-right {
+      margin-left: 20px;
+    }
+
+    .badge-left {
+      margin: 0 10px 0 0;
+    }
+  }
+}
+
+// these can't be nested because they don't appear under the modal
+.tooltip.show {
+  display: block;
+  z-index: 99999;
+}
+.popover {
+  z-index: 99999;
+
+  .popover-header {
+    margin: 0;
+  }
+
+  ul {
+    list-style-type: square;
+    padding: 0 20px;
+  }
+}
+
+// this is the place where the badges appear
+.reason-badges {
+  .badge {
+    margin-left: 3px;
+  }
+}

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -69,6 +69,35 @@ class TranslationsController < ApplicationController
 
   def edit
     @params = params
+
+    # reasons logic
+    @reasons = Reason.order(:category)
+    @reason_badges = []
+    @severity_badge = nil
+    severity_texts = TranslationChange.reason_severities.map {|s| s[0].titlecase}
+
+    changes = @translation.translation_changes.to_a
+    changes.sort! { |x,y| y <=> x }
+
+    @reason_badges = changes.map do |change|
+      change.reasons.map do |reason|
+        { id: reason.id, text: "#{reason.category}: #{reason.name}"}
+      end
+    end
+
+    @reason_badges.flatten!
+
+    latest_severity = changes.find {|c| c.reason_severity }
+    severity = latest_severity&.reason_severity
+
+    if severity
+      @severity_badge = {
+        class_name: TranslationChange::SEVERITY_CLASSES[severity],
+        severity: severity,
+        severity_text: "Severity: #{severity_texts[severity]}"
+      }
+    end
+
     respond_with @translation, location: project_key_translation_url(@project, @key, @translation)
   end
 

--- a/app/models/translation_change.rb
+++ b/app/models/translation_change.rb
@@ -27,6 +27,8 @@
 
 class TranslationChange < ActiveRecord::Base
   TRACKED_ATTRIBUTES = [:copy, :approved]
+  # Reason severity classes, note these must be in order, 0 - 3
+  SEVERITY_CLASSES = ['badge-success', 'badge-info', 'badge-warning', 'badge-danger']
 
   belongs_to :translation, inverse_of: :translation_changes
   belongs_to :user

--- a/app/views/locale/projects/show.js.coffee.erb
+++ b/app/views/locale/projects/show.js.coffee.erb
@@ -51,7 +51,8 @@ $(document).ready ->
     else
       new Flash('alert').text('Need to select a commit to view issues')
 
-  # TRANSLATION WORKBENCH
+  # TRANSLATION WORKBENCH and REASONS MODAL
+  new ReasonsModal('.translation-area.active')
   new TranslationWorkbench(
     $(".translation-workbench"),
     "<%= search_translations_url(:target_locales => @locale.rfc5646) %>",

--- a/app/views/locale/projects/show.slim
+++ b/app/views/locale/projects/show.slim
@@ -40,7 +40,7 @@
     strong
       - last_commit = @project.commits.order('committed_at DESC').first
       - if last_commit
-        | Last imported
+        | Last imported&nbsp;
         = "#{time_ago_in_words(last_commit.committed_at)} ago"
         |  /
         = "#{last_commit.revision_prefix}"

--- a/app/views/translations/edit.js.coffee.erb
+++ b/app/views/translations/edit.js.coffee.erb
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 $(document).ready ->
+  copy_changed = false
   find_fuzzy_matches = (source_copy, locale) ->
     loadFuzzyMatches($('.fuzzy-matches').first(),
                      copy_field,
@@ -21,7 +22,7 @@ $(document).ready ->
 
   source_copy = "<%= escape_javascript @translation.source_copy %>"
   target_locale = "<%= escape_javascript @translation.rfc5646_locale %>"
-
+  current_translation = "<%= escape_javascript @translation.copy %>"
   current_selection = source_copy
 
   blankString = $("input[name=blank_string]")
@@ -34,6 +35,7 @@ $(document).ready ->
 
   copy_field.keyup ->
     blankString[0].checked = copy_field.val().match(/^\s*$/)
+    copy_changed = @value != current_translation
     true
   $(".copy-source").click ->
     copy_field.val "<%= escape_javascript @translation.source_copy %>"
@@ -66,3 +68,25 @@ $(document).ready ->
 
   find_fuzzy_matches(source_copy, target_locale)
 
+
+  # Reasons logic
+  reasons_modal = new ReasonsModal('#translation_copy')
+  # handle the submit button
+  $('.edit-side input[type=submit].primary').click ->
+    # check server variables
+    enable_reasons = JSON.parse("<%= Shuttle::Configuration.workbench.enable_reasons %>")
+    role = '<%= current_user.role %>'
+    # only perform this logic if the user is a reviewer, the copy changed, and "reasons" is enabled
+    if enable_reasons && role == 'reviewer' && copy_changed
+      $('#reason_trigger').click()
+      false
+
+
+  # handle undo
+  $(document).on 'reasonsModal.undo', =>
+    copy_field.val(current_translation)
+  # handle save
+  $(document).on 'reasonsModal.save', (e, reason_ids, reason_severity) =>
+    $('#reason_ids').val(reason_ids)
+    $('#reason_severity').val(reason_severity)
+    $('#large-translation').submit()

--- a/app/views/translations/edit.slim
+++ b/app/views/translations/edit.slim
@@ -41,6 +41,16 @@ hr.divider
 
         .control-group
           = f.text_area :copy, autocomplete: 'off', rows: 15, class: 'resize'
+          = hidden_field_tag :reason_ids
+          = hidden_field_tag :reason_severity
+          .reason-badges
+            - if @severity_badge
+              span.badge.severity-badge.saved class="#{@severity_badge[:class_name]}" data-severity="#{@severity_badge[:severity]}"
+                = @severity_badge[:severity_text]
+
+            - @reason_badges.each do |badge|
+              span.badge.badge-secondary.saved data-checkbox="#{badge[:id]}"
+                = badge[:text]
 
         .control-group
           = check_box_tag 'blank_string', '1', (@translation.translated? && @translation.copy.blank? ? 'checked' : nil)
@@ -74,3 +84,5 @@ hr.divider
       = render partial: (@translation.belongs_to_article? ? 'article_details' : 'commit_history'), locals: { translation: @translation }
 
 = render partial: 'issues/index', locals: {project: @project, key: @key, translation: @translation, issues: @issues, issue: @issue}
+button type='button' id='reason_trigger' href='#add-translation-reasons' style='display:none' rel='modal' Trigger
+= render partial: 'locale/projects/reason_modal', locals: { reasons: @reasons }


### PR DESCRIPTION
This PR adds the reasons workflow to the Translation Edit/Detail screen. You can now see the badges and modify them within the workbench or the edit screen.

There is a second commit in this PR for a change after discussion with Ace. Temporary badges are no longer visible if you close the modal window.
