### PR TITLE
Removed duplicate enable_reasons

### DIFF
--- a/config/environments/production/features.yml
+++ b/config/environments/production/features.yml
@@ -1,2 +1,1 @@
-enable_reasons: true
 enable_assets: true

--- a/config/environments/staging/features.yml
+++ b/config/environments/staging/features.yml
@@ -1,2 +1,1 @@
-enable_reasons: true
 enable_assets: true

--- a/config/environments/test/features.yml
+++ b/config/environments/test/features.yml
@@ -1,2 +1,1 @@
-enable_reasons: true
 enable_assets: true


### PR DESCRIPTION
I removed the duplicate `enable_reasons` from Shuttle. These are not used. The one that is used is in `Shuttle::Configuration.workbench` since it's a workbench specific flag.