### PR TITLE
Improve commit loading time.

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -352,11 +352,10 @@ class Commit < ActiveRecord::Base
 
   def import_blob(path, git_blob)
     return if project.skip_tree?(path)
-    imps = Importer::Base.implementations.reject { |imp| project.skip_imports.include?(imp.ident) }
 
     blob = project.blobs.with_sha(git_blob[:oid]).with_path(path).find_or_create!(sha: git_blob[:oid], path: path)
 
-    imps.each do |importer|
+    project.required_importers.each do |importer|
       importer = importer.new(blob, self)
       next if importer.skip?
       BlobImporter.perform_once importer.class.ident, blob.id, id

--- a/lib/importer/base.rb
+++ b/lib/importer/base.rb
@@ -85,14 +85,14 @@ module Importer
       @blob   = blob
       @commit = commit
       @file   = File.new(blob.path, nil)
-
-      blob.blobs_commits.where(commit_id: @commit.id).find_or_create!
     end
 
     # Scans the Blob for localizable strings, and creates or updates
     # corresponding Translation records.
 
     def import
+      @blob.blobs_commits.where(commit_id: @commit.id).find_or_create!
+
       if @blob.parsed?
         import_by_using_cached_keys
       else

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -314,7 +314,9 @@ RSpec.describe Commit do
       @project = FactoryBot.create(:project, :light)
       commit = @project.commit!('HEAD')
       CommitImporter::Finisher.new.on_success(true, 'commit_id' => commit.id)
-      expect(Blob.where(parsed: false).count).to be_zero
+      expect(@project.blobs.count).to eql(2)
+      expect(commit.blobs.count).to eql(1)
+      expect(commit.blobs.where(parsed: false).count).to be_zero
     end
 
     it "should remove appropriate keys when reimporting after changed settings" do
@@ -354,14 +356,18 @@ RSpec.describe Commit do
       @commit.send(:import_blob, '/config/locales/en.yml', @file1)
       @commit.send(:import_blob, '/config/locales/en-US.yml', @file2)
 
-      expect(@commit.reload.blobs.count).to eql(2)
+      expect(@project.blobs.count).to eql(2)
+      expect(@commit.blobs.count).to be_zero
     end
 
     it "doesn't create a new blob if the file has already been imported before" do
       @commit.send(:import_blob, '/config/locales/en.yml', @file1)
-      expect(@commit.reload.blobs.count).to eql(1)
+      expect(@project.blobs.count).to eql(1)
+      expect(@commit.blobs.count).to be_zero
+
       @commit.send(:import_blob, '/config/locales/en.yml', @file2)
-      expect(@commit.reload.blobs.count).to eql(1)
+      expect(@project.blobs.count).to eql(1)
+      expect(@commit.blobs.count).to be_zero
     end
   end
 


### PR DESCRIPTION
Summary of changes:
 - Delay associating a blob with a commit until it's imported.
 - Matches project only_paths and skip_paths with patterns.
 - Cache required importers in project object.