### PR TITLE
Assets Docx Fixes

### DIFF
--- a/app/workers/asset_docx_importer.rb
+++ b/app/workers/asset_docx_importer.rb
@@ -32,7 +32,7 @@ class AssetDocxImporter
           cells << {
             node: cell.node,
             text: cell.text,
-            background_color: cell.xpath('.//w:shd/@w:fill').first&.value
+            background_color: cell.xpath('.//w:shd/@w:fill').first&.value || cell.xpath('.//w:highlight/@w:val').first&.value
           }
         end
       end

--- a/app/workers/asset_docx_importer.rb
+++ b/app/workers/asset_docx_importer.rb
@@ -10,9 +10,7 @@
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
-#    limitations under the License.
-require 'awesome_print'
-
+#    limitations under the License
 class AssetDocxImporter
   # @param [Fixnum] asset_id The ID of a Asset
   def import(asset_id)
@@ -23,7 +21,7 @@ class AssetDocxImporter
       paragraphs << {
         node: paragraph.node,
         text: paragraph.text,
-        background_color: paragraph.xpath('.//w:shd/@w:fill').first&.value,
+        background_color: paragraph.xpath('.//w:shd/@w:fill').first&.value || paragraph.xpath('.//w:highlight/@w:val').first&.value,
         index: index
       }
     end
@@ -49,7 +47,7 @@ class AssetDocxImporter
       paragraph[:node] = cell[:node]
     end
 
-    paragraphs.select! { |p| %w[fefb00 ffff00 fdfc00].include?(p[:background_color]) }
+    paragraphs.select! { |p| %w[yellow fefb00 ffff00 fdfc00].include?(p[:background_color]) }
     paragraphs.each do |p|
       process_paragraph(p, p[:index])
     end

--- a/lib/exporter/asset.rb
+++ b/lib/exporter/asset.rb
@@ -79,14 +79,26 @@ private
       asset.translations.in_locale(locale).each do |translation|
         para_info = translation.key.original_key.scan(/paragraph(\d+)-sentence(\d+)/).flatten
         paragraph_index = para_info[0].to_i
-        sentence_index = para_info[1].to_i
+        # sentence_index = para_info[1].to_i + 1
 
         paragraph = doc.paragraphs[paragraph_index]
-        if sentence_index > 0
-          paragraph.text = paragraph.text + ' ' + translation.copy
-        else
-          paragraph.text = translation.copy
+        text_runs = paragraph.xpath('.//w:t')
+        hyperlink_run = paragraph.xpath('.//w:r[w:rPr[w:rStyle[@w:val="Hyperlink.0"]] and ./w:t]/.//w:t').first
+
+        text_runs.each_with_index do |t, i|
+          if hyperlink_run
+            if hyperlink_run == t
+              t.content = translation.copy
+            else
+              t.remove
+            end
+          elsif i.zero?
+            t.content = translation.copy
+          else
+            t.remove
+          end
         end
+
       end
       filename = Rails.root.join('tmp', "#{asset.file_name}.docx")
       doc.save(filename.to_s)

--- a/spec/workers/asset_docx_importer_spec.rb
+++ b/spec/workers/asset_docx_importer_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AssetXlsxImporter do
+RSpec.describe AssetDocxImporter do
   describe "#perform" do
     before :each do
       @project = FactoryBot.create(:project, targeted_rfc5646_locales: { 'es' => true })


### PR DESCRIPTION
This PR includes Asset DOCX fixes, namely, selecting highlighted text and including the hyperlink in the resulting file.

In terms of future work to complete, the URL is exposed in the translation workbench. This was intended to let the user change the URL when building the resulting documents. The idea here is to choose a tag as a placeholder that would wrap what the user wants to make into a link. The resulting doc would have the URL inserted around the user selected text with user edited URL. All that happens now is the whole `translation.copy` ends up as the link