### PR TITLE
Asset fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'mustache'
 gem 'html_validation'
 gem 'diff-lcs'
 gem 'rubyXL', github: 'weshatheleopard/rubyXL'
-gem 'docx'
+gem 'docx', github: 'visoft/docx'
 
 # EXPORTING
 gem 'libarchive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,14 @@ GIT
       mimemagic (= 0.3.0)
 
 GIT
+  remote: https://github.com/visoft/docx.git
+  revision: ea5859703590f091b009cb5918a110e9f059a81b
+  specs:
+    docx (0.3.0)
+      nokogiri (~> 1.8, >= 1.8.1)
+      rubyzip (~> 1.2, >= 1.2.1)
+
+GIT
   remote: https://github.com/weshatheleopard/rubyXL.git
   revision: 74b4717c298a9eb19710d402eee00b210edcff05
   specs:
@@ -165,9 +173,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
-    docx (0.3.0)
-      nokogiri (~> 1.8, >= 1.8.1)
-      rubyzip (~> 1.2, >= 1.2.1)
     dropzonejs-rails (0.8.2)
       rails (> 3.1)
     elasticsearch (5.0.4)
@@ -493,7 +498,7 @@ DEPENDENCIES
   database_cleaner
   devise
   diff-lcs
-  docx
+  docx!
   dropzonejs-rails
   elasticsearch (< 6.0)
   elasticsearch-dsl

--- a/app/workers/asset_docx_importer.rb
+++ b/app/workers/asset_docx_importer.rb
@@ -54,7 +54,12 @@ class AssetDocxImporter
   end
 
   def get_document(file)
-    Docx::Document.open(file.path)
+    if File.file?(file.path)
+      Docx::Document.open(file.path)
+    else
+      content = open(file.url).read
+      Docx::Document.open_buffer(content)
+    end
   end
 
   def process_paragraph(paragraph, index)
@@ -93,6 +98,6 @@ class AssetDocxImporter
   def generate_key_name(index, sentence_index, sentence)
     file_name = @asset.file_name.gsub(' ', '_').downcase
     hashed_value = Digest::SHA1.hexdigest(sentence)
-    "#{file_name}-paragraph#{index}-sentence#{sentence_index}-#{hashed_value}"
+    "#{file_name}-paragraph#{index}-sentence#{sentence_index}-p#{@asset.project.id}-#{hashed_value}"
   end
 end

--- a/app/workers/asset_xlsx_importer.rb
+++ b/app/workers/asset_xlsx_importer.rb
@@ -61,6 +61,6 @@ class AssetXlsxImporter
   def generate_key_name(worksheet_index, cell)
     file_name = @asset.file_name.gsub(' ', '_').downcase
     hashed_value = Digest::SHA1.hexdigest(cell.value)
-    "#{file_name}-sheet#{worksheet_index}-row#{cell.row}-col#{cell.column}-#{hashed_value}"
+    "#{file_name}-sheet#{worksheet_index}-row#{cell.row}-col#{cell.column}-p#{@asset.project.id}-#{hashed_value}"
   end
 end

--- a/lib/exporter/asset.rb
+++ b/lib/exporter/asset.rb
@@ -74,12 +74,11 @@ private
         doc = Docx::Document.open(asset.file.path)
       else
         content = open(asset.file.url).read
-        doc = Docx::Document.open(content)
+        doc = Docx::Document.open_buffer(content)
       end
       asset.translations.in_locale(locale).each do |translation|
         para_info = translation.key.original_key.scan(/paragraph(\d+)-sentence(\d+)/).flatten
         paragraph_index = para_info[0].to_i
-        # sentence_index = para_info[1].to_i + 1
 
         paragraph = doc.paragraphs[paragraph_index]
         text_runs = paragraph.xpath('.//w:t')

--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -94,13 +94,13 @@ module Reports
         .joins('LEFT OUTER JOIN articles ON articles.id = article_id')
         .joins('LEFT OUTER JOIN commits ON commits.revision = sha')
         .joins('LEFT OUTER JOIN assets ON assets.id = asset_id')
-        .group('DATE(translation_changes.created_at)')
+        .group('DATE(COALESCE(translations.review_date , translations.translation_date))')
         .group('articles.name, sha, assets.id')
         .order('group_id', 'rfc5646_locale', 'source_rfc5646_locale', 'projects.name', 'first_name', 'classification')
         .select('RANK() OVER (
-                   ORDER BY DATE(translation_changes.created_at), rfc5646_locale, projects.name, sha, articles.name, assets.id, first_name
+                   ORDER BY DATE(COALESCE(translations.review_date , translations.translation_date)), rfc5646_locale, projects.name, sha, articles.name, assets.id, first_name
                  ) AS group_id,
-                 DATE(translation_changes.created_at) as "date",
+                 DATE(COALESCE(translations.review_date , translations.translation_date)) as "date",
                  sha,
                  articles.name as article_name,
                  assets.id as asset_id,

--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -68,7 +68,7 @@ module Reports
         query = query.where("users.email ~ '^(?!.*(#{internal_domains})$).*$'")
       end
 
-      query.where('translation_changes.tm_match IS NOT NULL')
+      query = query.where('translation_changes.tm_match IS NOT NULL')
            .where('translations.rfc5646_locale': languages)
            .joins(:project, :user, :translation)
            .group('source_rfc5646_locale, rfc5646_locale, translation_changes.role, projects.name, projects.job_type, first_name, users.id, classification')
@@ -82,6 +82,7 @@ module Reports
                    -- the following take the tm_match and converts it to a number 0-5
                    CASE WHEN translation_changes.tm_match < 60 THEN 0 ELSE FLOOR((translation_changes.tm_match - 50)/10) END as classification,
                    SUM(words_count) as words_count')
+      query.latest_changes
     end
 
     def self.get_standard_query(start_date, end_date, languages, exclude_internal)

--- a/lib/reports/translator_report.rb
+++ b/lib/reports/translator_report.rb
@@ -56,7 +56,7 @@ module Reports
           asset = (tc.asset_id.blank?) ? nil : tc.asset_id
           job_start = (tc.job_start ? tc.job_start.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
           approved_at = (tc.approved_at ? tc.approved_at.in_time_zone.strftime('%Y-%m-%d %H:%M') : '')
-          
+
           csv << [tc.date.strftime('%Y-%m-%d'), tc.first_name, tc.user_id, tc.role, tc.source_rfc5646_locale.upcase, tc.rfc5646_locale.upcase, tc.project_name, Project.job_types.key(tc.job_type).titlecase, (sha || article || asset).to_s, job_start, approved_at, counts].flatten
         end
       end
@@ -85,7 +85,12 @@ module Reports
     end
 
     def self.get_standard_query(start_date, end_date, languages, exclude_internal)
-      query = TranslationChange.where('translation_changes.created_at': start_date.beginning_of_day..end_date.end_of_day)
+      query = TranslationChange.where(
+            'translations.translation_date BETWEEN ? AND ? OR translations.review_date BETWEEN ? AND ?',
+            start_date.beginning_of_day, end_date.end_of_day,
+            start_date.beginning_of_day, end_date.end_of_day
+
+        )
         .joins('LEFT OUTER JOIN articles ON articles.id = article_id')
         .joins('LEFT OUTER JOIN commits ON commits.revision = sha')
         .joins('LEFT OUTER JOIN assets ON assets.id = asset_id')

--- a/spec/lib/reports/translator_report_spec.rb
+++ b/spec/lib/reports/translator_report_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Reports::TranslatorReport do
         t1 = FactoryBot.create(:translation, key: key1, rfc5646_locale: 'fr', tm_match: 71, source_copy: 'One two three', translation_date: @start_date, review_date: @start_date, reviewer: @reviewer, translator: @translator)
         FactoryBot.create(:translation_change, translation: t1, project: @project, sha: @commit.revision, is_edit: false, user: @translator, role: 'translator', created_at: @start_date, tm_match: t1.tm_match)
         FactoryBot.create(:translation_change, translation: t1, project: @project, sha: @commit.revision, is_edit: true, user: @reviewer, role: 'reviewer', created_at: @start_date, tm_match: t1.tm_match)
+        FactoryBot.create(:translation_change, translation: t1, project: @project, sha: @commit.revision, is_edit: true, user: @reviewer, role: 'reviewer', created_at: @start_date + 1.day, tm_match: t1.tm_match)
 
         t2 = FactoryBot.create(:translation, key: key2, rfc5646_locale: 'it', tm_match: 85, source_copy: 'One two three', translation_date: @start_date, review_date: @start_date, reviewer: @reviewer, translator: @translator)
         FactoryBot.create(:translation_change, translation: t2, project: @project, sha: @commit.revision, is_edit: false, user: @translator, role: 'translator', created_at: @start_date, tm_match: t2.tm_match)

--- a/spec/workers/asset_docx_importer_spec.rb
+++ b/spec/workers/asset_docx_importer_spec.rb
@@ -39,5 +39,9 @@ RSpec.describe AssetDocxImporter do
       expect(@asset.translations.count).to eq 48
     end
 
+    it 'sets the proper key name' do
+      hashed_value = Digest::SHA1.hexdigest(@asset.keys.first.source_copy)
+      expect(@asset.keys.first.original_key).to eq "#{@asset.file_name}-paragraph15-sentence0-p#{@project.id}-#{hashed_value}"
+    end
   end
 end

--- a/spec/workers/asset_importer_spec.rb
+++ b/spec/workers/asset_importer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe AssetImporter do
 
       it 'sets the proper key name' do
         hashed_value = Digest::SHA1.hexdigest(@asset.keys.first.source_copy)
-        expect(@asset.keys.first.original_key).to eq "#{@asset.file_name}-sheet0-row1-col1-#{hashed_value}"
+        expect(@asset.keys.first.original_key).to eq "#{@asset.file_name}-sheet0-row1-col1-p#{@asset.project.id}-#{hashed_value}"
       end
     end
   end

--- a/spec/workers/asset_xlsx_importer_spec.rb
+++ b/spec/workers/asset_xlsx_importer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AssetXlsxImporter do
     it 'sets the key to the correct name' do
       expect(@asset.keys.count).to eq 1
       hashed_value = Digest::SHA1.hexdigest(@asset.keys.first.source_copy)
-      expect(@asset.keys.first.key).to eq "#{@asset.file_name.downcase}-sheet0-row1-col1-#{hashed_value}"
+      expect(@asset.keys.first.key).to eq "#{@asset.file_name.downcase}-sheet0-row1-col1-p#{@project.id}-#{hashed_value}"
     end
   end
 end


### PR DESCRIPTION
This PR includes the translator report changes found in https://github.com/square/shuttle/pull/227. I can rebase if you'd like this to be on it's own.

The fixes contained here allow for Docx files to be opened via a stream (e.g. a file hosted on AWS), and the auto TM is for assets is now scoped to the project. This is achieved by including the project Id as part of the asset key.