### PR TITLE
Rebuilt paragraphs

### DIFF
--- a/lib/exporter/asset.rb
+++ b/lib/exporter/asset.rb
@@ -88,7 +88,7 @@ private
         text_runs = paragraph.xpath('.//w:t')
         hyperlink_run = paragraph.xpath('.//w:r[w:rPr[w:rStyle[@w:val="Hyperlink.0"]] and ./w:t]/.//w:t').first
         run = hyperlink_run || text_runs.first
-        run.content = sentences.map(&:copy).join(' ')
+        run.content = sentences.sort_by { |t| t.key.original_key}.map(&:copy).join(' ')
         text_runs.each { |r| r.remove unless r == run }
       end
       doc.stream


### PR DESCRIPTION
This PR rebuilds the paragraphs from translations and uses the hyperlink text run or the first one as the placeholder. This can be enhanced to find something other than the first text run if needed (e.g. first formatted text run).

This fixes the issue where the manifest renders and incomplete document.