### PR TITLE
Changes for sorting, gem version, and default for no asset project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'mustache'
 gem 'html_validation'
 gem 'diff-lcs'
 gem 'rubyXL', github: 'weshatheleopard/rubyXL'
-gem 'docx', github: 'visoft/docx'
+gem 'docx', '0.3.1', github: 'visoft/docx'
 
 # EXPORTING
 gem 'libarchive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,9 +37,9 @@ GIT
 
 GIT
   remote: https://github.com/visoft/docx.git
-  revision: c7c5c01ad08487b6d39aeaceb07f3ae2552745c5
+  revision: e01969d8cd2f740c6fcf1d2d13a0d70c085a3277
   specs:
-    docx (0.3.0)
+    docx (0.3.1)
       nokogiri (~> 1.8, >= 1.8.1)
       rubyzip (~> 1.2, >= 1.2.1)
 
@@ -498,7 +498,7 @@ DEPENDENCIES
   database_cleaner
   devise
   diff-lcs
-  docx!
+  docx (= 0.3.1)!
   dropzonejs-rails
   elasticsearch (< 6.0)
   elasticsearch-dsl

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -15,7 +15,7 @@
 class Asset < ActiveRecord::Base
   belongs_to :project,    inverse_of: :assets
   belongs_to :user
-  has_many :assets_keys, inverse_of: :asset, dependent: :delete_all
+  has_many :assets_keys, inverse_of: :asset, dependent: :destroy
   has_many :keys, through: :assets_keys
   has_many :translations, through: :keys
 

--- a/app/services/locale_projects_show_finder.rb
+++ b/app/services/locale_projects_show_finder.rb
@@ -127,7 +127,7 @@ class LocaleProjectsShowFinder
     elsif form[:commit]
       translations = translations.order('commits_keys.created_at, keys.original_key')
     elsif form[:asset_id]
-      translations = translations.order('assets_keys.created_at, keys.original_key')
+      translations = translations.order('keys.original_key')
     elsif form[:group]
       translations = translations.joins({article: {article_groups: :group}}).where("groups.display_name = ?", form[:group])
       translations = translations.order('article_groups.index_in_group, keys.section_id, keys.index_in_section')

--- a/app/views/home/assets/_add_translation_modal.slim
+++ b/app/views/home/assets/_add_translation_modal.slim
@@ -24,3 +24,10 @@
         = select_tag 'new_project_asset_id', options_for_select(projects.map { |p| [p.name, new_project_asset_path(p.to_param)] })
 
         = link_to 'REQUEST', 'javascript: void(0);', class: 'button primary', id: 'request_new_project_asset_button'
+- else
+  .row
+    .modal.seven.columns#add-asset-translation
+      a.close ×
+      h2 Translation Request
+      .modal-body
+        strong Sorry, you must have an Asset Project created before requesting a translation.


### PR DESCRIPTION
This PR contains new sorting logic, a fixed docx gem version and a default if there is no asset projects yet. I've also changed the deletion strategy for assets_keys to destroy. I tested destroys locally and it worked ok, but my paperclip is set up to store locally.