### PR TITLE
Reverted sort to created_at and original key

### DIFF
--- a/app/services/locale_projects_show_finder.rb
+++ b/app/services/locale_projects_show_finder.rb
@@ -127,7 +127,7 @@ class LocaleProjectsShowFinder
     elsif form[:commit]
       translations = translations.order('commits_keys.created_at, keys.original_key')
     elsif form[:asset_id]
-      translations = translations.order('keys.original_key')
+      translations = translations.order('assets_keys.created_at, keys.original_key')
     elsif form[:group]
       translations = translations.joins({article: {article_groups: :group}}).where("groups.display_name = ?", form[:group])
       translations = translations.order('article_groups.index_in_group, keys.section_id, keys.index_in_section')


### PR DESCRIPTION
I reverted the sorting to use the key date and original key. In my testing this gave the correct results.